### PR TITLE
Allow to do variable substitution through environment variables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,8 +2,8 @@
 Change History for ZConfig
 ==========================
 
-3.0.5 (unreleased)
-------------------
+3.0.4+enfold1 (2015-04-09)
+--------------------------
 
 - Add ability to do variable substitution from environment variables using
   $() syntax.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,12 @@
 Change History for ZConfig
 ==========================
 
+3.0.4+enfold2 (unreleased)
+--------------------------
+
+- Nothing changed yet.
+
+
 3.0.4+enfold1 (2015-04-09)
 --------------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Change History for ZConfig
 3.0.5 (unreleased)
 ------------------
 
-- TBD
+- Add ability to do variable substitution from environment variables using
+  $() syntax.
 
 3.0.4 (2014-03-20)
 ------------------

--- a/ZConfig/tests/test_subst.py
+++ b/ZConfig/tests/test_subst.py
@@ -15,6 +15,7 @@
 
 # This is needed to support Python 2.1.
 from __future__ import nested_scopes
+import os
 
 import unittest
 
@@ -46,6 +47,9 @@ class SubstitutionTestCase(unittest.TestCase):
         check("$$", "$")
         check("$$$name$$", "$value$")
 
+        # Check for an ENV var
+        self.assertEqual(substitute("$(PATH)", d), os.getenv("PATH"))
+
     def test_undefined_names(self):
         d = {"name": "value"}
         self.assertRaises(SubstitutionReplacementError,
@@ -54,6 +58,10 @@ class SubstitutionTestCase(unittest.TestCase):
                           substitute, "$splat1", d)
         self.assertRaises(SubstitutionReplacementError,
                           substitute, "$splat_", d)
+
+        # An undefined ENV should also rise
+        self.assertRaises(SubstitutionReplacementError,
+                          substitute, "$(MY_SUPER_PATH)", d)
 
     def test_syntax_errors(self):
         d = {"name": "${next"}
@@ -64,6 +72,10 @@ class SubstitutionTestCase(unittest.TestCase):
         check("${name")
         check("${1name}")
         check("${ name}")
+        check("$(")
+        check("$(name")
+        check("$(1name)")
+        check("$( name)")
 
     def test_edge_cases(self):
         # It's debatable what should happen for these cases, so we'll

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def alltests():
 
 options = dict(
     name="ZConfig",
-    version='3.0.4+enfold1',
+    version='3.0.4+enfold2.dev0',
     author="Fred L. Drake, Jr.",
     author_email="fred@zope.com",
     maintainer="Zope Foundation and Contributors",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def alltests():
 
 options = dict(
     name="ZConfig",
-    version='3.0.5dev',
+    version='3.0.4+enfold1',
     author="Fred L. Drake, Jr.",
     author_email="fred@zope.com",
     maintainer="Zope Foundation and Contributors",


### PR DESCRIPTION
Not much to say here, added ability for ZConfig to expand variables using environment variables through the use of $( ) syntax e.g: $(PATH)