### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - 3.5
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,10 @@
 Change History for ZConfig
 ==========================
 
-3.1.1 (unreleased)
+3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 2.6 and 3.2.
 
 
 3.1.0 (2015-10-17)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def alltests():
 
 options = dict(
     name="ZConfig",
-    version='3.1.1.dev0',
+    version='3.2.0.dev0',
     author="Fred L. Drake, Jr.",
     author_email="fred@fdrake.net",
     maintainer="Zope Foundation and Contributors",
@@ -50,10 +50,8 @@ options = dict(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35
+envlist = py27,py33,py34,py35
 
 [testenv]
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
      zope.testrunner


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.