### PR TITLE
Add example support to SchemaType

### DIFF
--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -317,6 +317,7 @@ class SectionType:
         self.valuetype = valuetype
         self.handler = None
         self.description = None
+        self.example = None
         self.registry = registry
         self._children = []    # [(key, info), ...]
         self._attrmap = {}     # {attribute: info, ...}
@@ -504,6 +505,7 @@ def createDerivedSchema(base):
                      base.handler, base.url, base.registry)
     new._components.update(base._components)
     new.description = base.description
+    new.example = base.example
     new._children[:] = base._children
     new._attrmap.update(base._attrmap)
     new._keymap.update(base._keymap)

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -280,6 +280,9 @@ class BaseParser(xml.sax.ContentHandler):
         self._stack[-1].description = data
 
     def characters_example(self, data):
+        if self._stack[-1].example is not None:
+            self.error(
+                "at most one <example> may be used for each element")
         self._stack[-1].example = data
 
     def characters_metadefault(self, data):

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -56,7 +56,7 @@ class BaseParser(xml.sax.ContentHandler):
         "description": ["key", "section", "multikey", "multisection",
                         "sectiontype", "abstracttype",
                         "schema", "component"],
-        "example": ["key", "schema", "section", "multikey", "multisection"],
+        "example": ["key", "schema", "section", "sectiontype", "multikey", "multisection"],
         "metadefault": ["key", "section", "multikey", "multisection"],
         "default": ["key", "multikey"],
         "import": ["schema", "component"],

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -56,7 +56,7 @@ class BaseParser(xml.sax.ContentHandler):
         "description": ["key", "section", "multikey", "multisection",
                         "sectiontype", "abstracttype",
                         "schema", "component"],
-        "example": ["key", "section", "multikey", "multisection"],
+        "example": ["key", "schema", "section", "multikey", "multisection"],
         "metadefault": ["key", "section", "multikey", "multisection"],
         "default": ["key", "multikey"],
         "import": ["schema", "component"],

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -56,7 +56,7 @@ class BaseParser(xml.sax.ContentHandler):
         "description": ["key", "section", "multikey", "multisection",
                         "sectiontype", "abstracttype",
                         "schema", "component"],
-        "example": ["key", "schema", "section", "sectiontype", "multikey", "multisection"],
+        "example": ["schema", "sectiontype", "key", "multikey"],
         "metadefault": ["key", "section", "multikey", "multisection"],
         "default": ["key", "multikey"],
         "import": ["schema", "component"],

--- a/ZConfig/tests/test_schema.py
+++ b/ZConfig/tests/test_schema.py
@@ -1116,28 +1116,6 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
             """)
         self.assertEqual(schema.gettype('abc').getinfo('def').example, 'This is an example')
 
-    def test_section_example(self):
-        schema = self.load_schema_text("""\
-            <schema>
-                <sectiontype name="abc"/>
-                <section type="abc" name="def">
-                    <example>  This is an example  </example>
-                </section>
-            </schema>
-            """)
-        self.assertEqual(schema[0][1].example, 'This is an example')
-
-    def test_multisection_example(self):
-        schema = self.load_schema_text("""\
-            <schema>
-                <sectiontype name="abc"/>
-                <multisection type="abc" name="*" attribute="things">
-                    <example>  This is an example  </example>
-                </multisection>
-            </schema>
-            """)
-        self.assertEqual(schema[0][1].example, 'This is an example')
-
     def test_sectiontype_example(self):
         schema = self.load_schema_text("""\
             <schema>
@@ -1154,6 +1132,26 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
             <schema>
                 <example>  This is an example  </example>
                 <example>  This is an example  </example>
+            </schema>
+            """)
+
+    def test_section_example_is_error(self):
+        self.assertRaises(ZConfig.SchemaError, self.load_schema_text, """\
+            <schema>
+                <sectiontype name="abc"/>
+                <section type="abc" name="def">
+                    <example>  This is an example  </example>
+                </section>
+            </schema>
+            """)
+
+    def test_multisection_example_is_error(self):
+        self.assertRaises(ZConfig.SchemaError, self.load_schema_text, """\
+            <schema>
+                <sectiontype name="abc"/>
+                <multisection type="abc" name="*" attribute="things">
+                    <example>  This is an example  </example>
+                </multisection>
             </schema>
             """)
 

--- a/ZConfig/tests/test_schema.py
+++ b/ZConfig/tests/test_schema.py
@@ -1084,6 +1084,79 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
         self.assertEqual(_srepr('foo'), "'foo'")
         self.assertEqual(_srepr(FOO), "'foo'")
 
+    def test_schema_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <example>  This is an example  </example>
+            </schema>
+            """)
+        self.assertEqual(schema.example, 'This is an example')
+
+    def test_key_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <sectiontype name="abc">
+                    <key name="def">
+                        <example>  This is an example  </example>
+                    </key>
+                </sectiontype>
+            </schema>
+            """)
+        self.assertEqual(schema.gettype('abc').getinfo('def').example, 'This is an example')
+
+    def test_multikey_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <sectiontype name="abc">
+                    <multikey name="def">
+                        <example>  This is an example  </example>
+                    </multikey>
+                </sectiontype>
+            </schema>
+            """)
+        self.assertEqual(schema.gettype('abc').getinfo('def').example, 'This is an example')
+
+    def test_section_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <sectiontype name="abc"/>
+                <section type="abc" name="def">
+                    <example>  This is an example  </example>
+                </section>
+            </schema>
+            """)
+        self.assertEqual(schema[0][1].example, 'This is an example')
+
+    def test_multisection_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <sectiontype name="abc"/>
+                <multisection type="abc" name="*" attribute="things">
+                    <example>  This is an example  </example>
+                </multisection>
+            </schema>
+            """)
+        self.assertEqual(schema[0][1].example, 'This is an example')
+
+    def test_sectiontype_example(self):
+        schema = self.load_schema_text("""\
+            <schema>
+                <sectiontype name="abc">
+                    <example>  This is an example  </example>
+                </sectiontype>
+                <section type="abc" name="def"/>
+            </schema>
+            """)
+        self.assertEqual(schema.gettype('abc').example, 'This is an example')
+
+    def test_multiple_examples_is_error(self):
+        self.assertRaises(ZConfig.SchemaError, self.load_schema_text, """\
+            <schema>
+                <example>  This is an example  </example>
+                <example>  This is an example  </example>
+            </schema>
+            """)
+
 
 def test_suite():
     return unittest.makeSuite(SchemaTestCase)

--- a/doc/schema.dtd
+++ b/doc/schema.dtd
@@ -46,7 +46,7 @@
 <!ELEMENT metadefault (#PCDATA)*>
 <!ELEMENT example     (#PCDATA)*>
 
-<!ELEMENT sectiontype (description?, 
+<!ELEMENT sectiontype (description?, example?
                        (section | key | multisection | multikey)*)>
 <!ATTLIST sectiontype
           name       NMTOKEN  #REQUIRED

--- a/doc/schema.dtd
+++ b/doc/schema.dtd
@@ -82,7 +82,7 @@
           handler    NMTOKEN  #IMPLIED
           required   (yes|no) "no">
 
-<!ELEMENT section (description?)>
+<!ELEMENT section (description?, example?)>
 <!ATTLIST section
           name       CDATA    "*"
           attribute  NMTOKEN  #IMPLIED
@@ -90,7 +90,7 @@
           handler    NMTOKEN  #IMPLIED
           required   (yes|no) "no">
 
-<!ELEMENT multisection (description?)>
+<!ELEMENT multisection (description?, example?)>
 <!ATTLIST multisection
           name       CDATA    "*"
           attribute  NMTOKEN  #IMPLIED

--- a/doc/schema.dtd
+++ b/doc/schema.dtd
@@ -82,7 +82,7 @@
           handler    NMTOKEN  #IMPLIED
           required   (yes|no) "no">
 
-<!ELEMENT section (description?, example?)>
+<!ELEMENT section (description?)>
 <!ATTLIST section
           name       CDATA    "*"
           attribute  NMTOKEN  #IMPLIED
@@ -90,7 +90,7 @@
           handler    NMTOKEN  #IMPLIED
           required   (yes|no) "no">
 
-<!ELEMENT multisection (description?, example?)>
+<!ELEMENT multisection (description?)>
 <!ATTLIST multisection
           name       CDATA    "*"
           attribute  NMTOKEN  #IMPLIED

--- a/doc/zconfig.tex
+++ b/doc/zconfig.tex
@@ -415,7 +415,7 @@ The following elements are used to describe a schema:
   \end{attributedesc}
 \end{elementdesc}
 
-\begin{elementdesc}{sectiontype}{description?, (section | key |
+\begin{elementdesc}{sectiontype}{description?, example?, (section | key |
                                   multisection | multikey)*}
   Define a concrete section type.
 


### PR DESCRIPTION
In schema.dtd the example tag is allowed inside the schema tag. This updates the parser to support it.