### PR TITLE
Move most class/method docs out of the rst and into docstrings

### DIFF
--- a/ZConfig/cmdline.py
+++ b/ZConfig/cmdline.py
@@ -20,9 +20,8 @@ overriding specific settings from the configuration file from the
 command line, without requiring the application to provide specific
 options for everything the configuration file can include.
 
-Each setting is described by a string of the form::
-
-    some/path/to/key=value
+Each setting is given by a value specifier string, as described by
+:meth:`ExtendedConfigLoader.addOption`.
 """
 
 import ZConfig
@@ -42,8 +41,20 @@ class ExtendedConfigLoader(ZConfig.loader.ConfigLoader):
     def addOption(self, spec, pos=None):
         """Add a single value to the list of overridden values.
 
-        The *spec* argument is a value specified, as described for the
-        :func:`~.loadConfig` function.
+        The *spec* argument is a value specifier string of the form
+        ``optionpath=value``. For example::
+
+            some/path/to/key=value
+
+        The *optionpath* specifies the "full path" to the
+        configuration setting: it can contain a sequence of names,
+        separated by ``/`` characters. Each name before the last names
+        a section from the configuration file, and the last name
+        corresponds to a key within the section identified by the
+        leading section names. If *optionpath* contains only one name,
+        it identifies a key in the top-level schema. *value* is a
+        string that will be treated just like a value in the
+        configuration file.
 
         A source position for the specifier may be given as *pos*. If
         *pos* is specified and not ``None``, it must be a sequence of

--- a/ZConfig/cmdline.py
+++ b/ZConfig/cmdline.py
@@ -174,9 +174,7 @@ class OptionBag(object):
         return string.lower()
 
 
-class MatcherMixin: # pylint:disable=old-style-class
-    # Can't extend object without getting __init__ errors due to
-    # parameters
+class MatcherMixin(object):
 
     def set_optionbag(self, bag):
         self.optionbag = bag

--- a/ZConfig/cmdline.py
+++ b/ZConfig/cmdline.py
@@ -12,11 +12,15 @@
 #
 ##############################################################################
 
-"""Support for command-line provision of settings.
+"""Support for command-line overrides for configuration settings.
 
-This module provides an extension of the ConfigLoader class which adds
-a way to add configuration settings from an alternate source.  Each
-setting is described by a string of the form::
+This module exports an extended version of the :class:`~.ConfigLoader`
+class from the :mod:`ZConfig.loader` module. This provides support for
+overriding specific settings from the configuration file from the
+command line, without requiring the application to provide specific
+options for everything the configuration file can include.
+
+Each setting is described by a string of the form::
 
     some/path/to/key=value
 """
@@ -27,11 +31,28 @@ import ZConfig.matcher
 
 
 class ExtendedConfigLoader(ZConfig.loader.ConfigLoader):
+    """A :class:`~.ConfigLoader` subclass that adds support for
+    command-line overrides.
+    """
+
     def __init__(self, schema):
         ZConfig.loader.ConfigLoader.__init__(self, schema)
         self.clopts = []   # [(optpath, value, source-position), ...]
 
     def addOption(self, spec, pos=None):
+        """Add a single value to the list of overridden values.
+
+        The *spec* argument is a value specified, as described for the
+        :func:`~.loadConfig` function.
+
+        A source position for the specifier may be given as *pos*. If
+        *pos* is specified and not ``None``, it must be a sequence of
+        three values. The first is the URL of the source (or some
+        other identifying string). The second and third are the line
+        number and column of the setting. These position information
+        is only used to construct a :exc:`~.DataConversionError` when
+        data conversion fails.
+        """
         if pos is None:
             pos = "<command-line option>", -1, -1
         if "=" not in spec:
@@ -66,7 +87,7 @@ class ExtendedConfigLoader(ZConfig.loader.ConfigLoader):
             return None
 
 
-class OptionBag:
+class OptionBag(object):
     def __init__(self, schema, sectiontype, options):
         self.sectiontype = sectiontype
         self.schema = schema
@@ -142,7 +163,10 @@ class OptionBag:
         return string.lower()
 
 
-class MatcherMixin:
+class MatcherMixin: # pylint:disable=old-style-class
+    # Can't extend object without getting __init__ errors due to
+    # parameters
+
     def set_optionbag(self, bag):
         self.optionbag = bag
 

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -45,15 +45,82 @@ except ImportError:
 
 
 def loadSchema(url):
+    """Load a schema definition from the URL *url*.
+
+    *url* may be a URL, absolute pathname, or relative pathname.
+    Fragment identifiers are not supported.
+
+    The resulting schema object can be passed to :func:`loadConfig` or
+    :func:`loadConfigFile`. The schema object may be used as many
+    times as needed.
+
+    .. seealso:: :class:`~.SchemaLoader`, :meth:`.BaseLoader.loadURL`
+    """
     return SchemaLoader().loadURL(url)
 
+
 def loadSchemaFile(file, url=None):
+    """Load a schema definition from the open file object *file*.
+
+    If *url* is given and not ``None``, it should be the URL of
+    resource represented by *file*. If *url* is omitted or ``None``, a
+    URL may be computed from the ``name`` attribute of *file*, if
+    present. The resulting schema object can be passed to
+    :func:`loadConfig` or :func:`loadConfigFile`. The schema object
+    may be used as many times as needed.
+
+    .. seealso:: :class:`~.SchemaLoader`, :meth:`.BaseLoader.loadFile`
+    """
     return SchemaLoader().loadFile(file, url)
 
+
 def loadConfig(schema, url, overrides=()):
+    """Load and return a configuration from a URL or pathname given by
+    *url*.
+
+    *url* may be a URL, absolute pathname, or relative pathname.
+    Fragment identifiers are not supported. *schema* is a reference to a
+    schema loaded by :func:`loadSchema` or :func:`loadSchemaFile`.
+
+    The return value is a tuple containing the configuration object and
+    a composite handler that, when called with a name-to-handler
+    mapping, calls all the handlers for the configuration.
+
+    The optional *overrides* argument represents information derived
+    from command-line arguments. If given, it must be either a
+    sequence of value specifiers, or ``None``. A "value specifier" is
+    a string of the form ``optionpath=value``, for example,
+    ``some/path/to/key=value``.
+
+    .. seealso::
+       :meth:`.ExtendedConfigLoader.addOption`
+            For information on the format of value specifiers.
+       :class:`~.ConfigLoader`
+            For information about loading configs.
+       :meth:`.BaseLoader.loadURL`
+            For information about the format of *url*
+    """
     return _get_config_loader(schema, overrides).loadURL(url)
 
+
 def loadConfigFile(schema, file, url=None, overrides=()):
+    """Load and return a configuration from an opened file object.
+
+    If *url* is omitted, one will be computed based on the ``name``
+    attribute of *file*, if it exists. If no URL can be determined,
+    all ``%include`` statements in the configuration must use absolute
+    URLs. *schema* is a reference to a schema loaded by
+    :func:`loadSchema` or :func:`loadSchemaFile`.
+
+    The return value is a tuple containing the configuration object
+    and a composite handler that, when called with a name-to-handler
+    mapping, calls all the handlers for the configuration. The
+    *overrides* argument is the same as for the :func:`loadConfig`
+    function.
+
+    .. seealso:: :class:`~.ConfigLoader`, :meth:`.BaseLoader.loadFile`,
+       :meth:`.ExtendedConfigLoader.addOption`
+    """
     return _get_config_loader(schema, overrides).loadFile(file, url)
 
 

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -16,7 +16,6 @@
 import os.path
 import re
 import sys
-import urllib
 
 import ZConfig
 import ZConfig.cfgparser
@@ -69,14 +68,32 @@ def _get_config_loader(schema, overrides):
     return loader
 
 
-class BaseLoader:
+class BaseLoader(object):
+    """Base class for loader objects.
+
+    This should not be instantiated
+    directly, as the :meth:`loadResource` method must be overridden
+    for the instance to be used via the public API.
+    """
+
     def __init__(self):
         pass
 
     def createResource(self, file, url):
+        """Returns a resource object for an open file and URL, given as *file*
+        and *url*, respectively.
+
+        This may be overridden by a subclass if an alternate resource
+        implementation is desired.
+        """
         return Resource(file, url)
 
     def loadURL(self, url):
+        """Open and load a resource specified by the URL *url*.
+
+        This method uses the :meth:`loadResource` method to perform the
+        actual load, and returns whatever that method returns.
+        """
         url = self.normalizeURL(url)
         r = self.openResource(url)
         try:
@@ -85,6 +102,16 @@ class BaseLoader:
             r.close()
 
     def loadFile(self, file, url=None):
+        """Load from an open file object, *file*.
+
+        If given and not ``None``, *url* should be the URL of the
+        resource represented by *file*. If omitted or *None*, the
+        ``name`` attribute of *file* is used to compute a ``file:``
+        URL, if present.
+
+        This method uses the :meth:`loadResource` method to perform the
+        actual load, and returns whatever that method returns.
+        """
         if not url:
             url = _url_from_file(file)
         r = self.createResource(file, url)
@@ -96,10 +123,23 @@ class BaseLoader:
     # utilities
 
     def loadResource(self, resource):
+        """Abstract method.
+
+        Subclasses of :class:`BaseLoader` must implement this method to
+        actually load the resource and return the appropriate
+        application-level object.
+        """
         raise NotImplementedError(
             "BaseLoader.loadResource() must be overridden by a subclass")
 
     def openResource(self, url):
+        """Returns a resource object that represents the URL *url*.
+
+        The URL is opened using the :func:`urllib2.urlopen` function,
+        and the returned resource object is created using
+        :meth:`createResource`. If the URL cannot be opened,
+        :exc:`~.ConfigurationError` is raised.
+        """
         # ConfigurationError exceptions raised here should be
         # str()able to generate a message for an end user.
         #
@@ -145,6 +185,17 @@ class BaseLoader:
             url)
 
     def normalizeURL(self, url):
+        """Return a URL for *url*
+
+        If *url* refers to an existing file, the corresponding
+        ``file:`` URL is returned. Otherwise *url* is checked
+        for sanity: if it does not have a schema, :exc:`ValueError` is
+        raised, and if it does have a fragment identifier,
+        :exc:`~.ConfigurationError` is raised.
+
+        This uses :meth:`isPath` to determine whether *url* is
+        a URL of a filesystem path.
+        """
         if self.isPath(url):
             url = "file://" + pathname2url(os.path.abspath(url))
         newurl, fragment = ZConfig.url.urldefrag(url)
@@ -159,7 +210,9 @@ class BaseLoader:
     _pathsep_rx = re.compile(r"[a-zA-Z][-+.a-zA-Z0-9]*:")
 
     def isPath(self, s):
-        """Return True iff 's' should be handled as a filesystem path."""
+        """Return true if *s* should be considered a filesystem path rather
+        than a URL.
+        """
         if ":" in s:
             # XXX This assumes that one-character scheme identifiers
             # are always Windows drive letters; I don't know of any
@@ -215,6 +268,14 @@ def _url_from_file(file):
 
 
 class SchemaLoader(BaseLoader):
+    """ Loader that loads schema instances.
+
+    All schema loaded by a :class:`SchemaLoader` will use the same
+    data type registry. If *registry* is provided and not ``None``, it
+    will be used, otherwise an instance of
+    :class:`ZConfig.datatypes.Registry` will be used.
+    """
+
     def __init__(self, registry=None):
         if registry is None:
             registry = ZConfig.datatypes.Registry()
@@ -258,6 +319,15 @@ class SchemaLoader(BaseLoader):
 
 
 class ConfigLoader(BaseLoader):
+    """Loader for configuration files.
+
+    Each configuration file must
+    conform to the schema *schema*.  The ``load*()`` methods
+    return a tuple consisting of the configuration object and a
+    composite handler.
+    """
+
+
     def __init__(self, schema):
         if schema.isabstract():
             raise ZConfig.SchemaError(
@@ -353,7 +423,19 @@ class CompositeHandler:
         return len(self._handlers)
 
 
-class Resource:
+class Resource(object):
+    """Object that allows an open file object and a URL to be bound
+    together to ease handling.
+
+    Instances have the attributes :attr:`file` and :attr:`url`, which
+    store the constructor arguments. These objects also have a
+    :meth:`close` method which will call :meth:`~file.close` on
+    *file*, then set the :attr:`file` attribute to ``None`` and the
+    :attr:`closed` attribute to ``True``.
+
+    All other attributes are delegated to *file*.
+    """
+
     def __init__(self, file, url):
         self.file = file
         self.url = url

--- a/ZConfig/matcher.py
+++ b/ZConfig/matcher.py
@@ -18,7 +18,7 @@ import ZConfig
 from ZConfig.info import ValueInfo
 
 
-class BaseMatcher:
+class BaseMatcher(object):
     def __init__(self, info, type, handlers):
         self.info = info
         self.type = type
@@ -254,7 +254,7 @@ class SchemaMatcher(BaseMatcher):
         return v
 
 
-class SectionValue:
+class SectionValue(object):
     """Generic 'bag-of-values' object for a section.
 
     Derived classes should always call the SectionValue constructor

--- a/ZConfig/substitution.py
+++ b/ZConfig/substitution.py
@@ -11,14 +11,22 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Substitution support for ZConfig values."""
+"""Shell-style string substitution helper."""
 
 import os
 import ZConfig
 
 
 def substitute(s, mapping):
-    """Interpolate variables from `mapping` into `s`."""
+    """Substitute values from *mapping* into *s*.
+
+    *mapping* can be a :class:`dict` or any type that supports the
+    ``get()`` method of the mapping protocol. Replacement values are
+    copied into the result without further interpretation. Raises
+    :exc:`~.SubstitutionSyntaxError` if there are malformed constructs
+    in *s*.
+    """
+
     if "$" in s:
         result = ''
         rest = s
@@ -41,7 +49,10 @@ def substitute(s, mapping):
 
 
 def isname(s):
-    """Return True iff s is a valid substitution name."""
+    """Returns ``True`` if *s* is a valid name for a substitution
+    text, otherwise returns ``False``.
+    """
+
     m = _name_match(s)
     if m:
         return m.group() == s

--- a/doc/py-mod-cmdline.rst
+++ b/doc/py-mod-cmdline.rst
@@ -2,34 +2,13 @@
  ZConfig.cmdline --- Command-line override support
 ===================================================
 
-.. py:module:: ZConfig.cmdline
-   :synopsis: Support for command-line overrides for configuration settings.
+.. automodule:: ZConfig.cmdline
 
-This module exports an extended version of the :class:`ZConfig.loader.ConfigLoader`
-class from the :mod:`ZConfig.loader` module.  This provides
-support for overriding specific settings from the configuration file
-from the command line, without requiring the application to provide
-specific options for everything the configuration file can include.
-
-.. py:class:: ExtendedConfigLoader(schema)
-
-  Construct a :class:`ConfigLoader` subclass that adds support for
-  command-line overrides.
-
+.. autoclass:: ExtendedConfigLoader(schema)
+   :show-inheritance:
 
 The following additional method is provided, and is the only way to
 provide position information to associate with command-line
 parameters:
 
-.. py:method:: ExtendedConfigLoader.addOption(spec [, pos])
-
-  Add a single value to the list of overridden values.  The *spec*
-  argument is a value specified, as described for the
-  :func:`ZConfig.loadConfig` function.  A source
-  position for the specifier may be given as *pos*.  If *pos*
-  is specified and not ``None``, it must be a sequence of three
-  values.  The first is the URL of the source (or some other
-  identifying string).  The second and third are the line number and
-  column of the setting.  These position information is only used to
-  construct a :exc:`~.DataConversionError` when data conversion
-  fails.
+.. automethod:: ExtendedConfigLoader.addOption

--- a/doc/py-mod-datatypes.rst
+++ b/doc/py-mod-datatypes.rst
@@ -2,88 +2,18 @@
  ZConfig.datatypes --- Default data type registry
 ==================================================
 
-.. py:module:: ZConfig.datatypes
-   :synopsis: Default implementation of a data type registry
+.. automodule:: ZConfig.datatypes
 
-The :mod:`ZConfig.datatypes` module provides the implementation of
-the default data type registry and all the standard data types
-supported by :mod:`ZConfig`.  A number of convenience classes are
-also provided to assist in the creation of additional data types.
-
-A "datatype registry" is an object that provides conversion
-functions for data types.  The interface for a registry is fairly
-simple.
-
-A "conversion function" is any callable object that accepts a
-single argument and returns a suitable value, or raises an exception
-if the input value is not acceptable.  :exc:`ValueError` is the
-preferred exception for disallowed inputs, but any other exception
-will be properly propagated.
-
-.. py:class:: Registry([stock])
-
-  Implementation of a simple type registry.  If given, *stock*
-  should be a mapping which defines the "built-in" data types for
-  the registry; if omitted or ``None``, the standard set of data
-  types is used (see :ref:`standard-datatypes`).
-
-
-
-:class:`Registry` objects have the following methods:
-
-.. py:method:: Registry.get(name)
-
-  Return the type conversion routine for *name*.  If the
-  conversion function cannot be found, an (unspecified) exception is
-  raised.  If the name is not provided in the stock set of data types
-  by this registry and has not otherwise been registered, this method
-  uses the :meth:`search` method to load the conversion function.
-  This is the only method the rest of :mod:`ZConfig` requires.
-
-
-.. py:method:: Registry.register(name, conversion)
-
-  Register the data type name *name* to use the conversion
-  function *conversion*.  If *name* is already registered or
-  provided as a stock data type, :exc:`ValueError` is raised
-  (this includes the case when *name* was found using the
-  :meth:`search` method).
-
-
-.. py:method:: Registry.search(name)
-
-  This is a helper method for the default implementation of the
-  :meth:`get` method.  If *name* is a Python dotted-name, this
-  method loads the value for the name by dynamically importing the
-  containing module and extracting the value of the name.  The name
-  must refer to a usable conversion function.
-
+.. autoclass:: Registry
+   :members: get, register, search
 
 
 The following classes are provided to define conversion functions:
 
-.. py:class:: MemoizedConversion(conversion)
-
-  Simple memoization for potentially expensive conversions.  This
-  conversion helper caches each successful conversion for re-use at a
-  later time; failed conversions are not cached in any way, since it
-  is difficult to raise a meaningful exception providing information
-  about the specific failure.
+.. autoclass:: MemoizedConversion
 
 
-.. py:class:: RangeCheckedConversion(conversion,[min [, max]])
-
-  Helper that performs range checks on the result of another
-  conversion.  Values passed to instances of this conversion are
-  converted using *conversion* and then range checked.  *min*
-  and *max*, if given and not ``None``, are the inclusive
-  endpoints of the allowed range.  Values returned by *conversion*
-  which lay outside the range described by *min* and *max*
-  cause :exc:`ValueError` to be raised.
+.. autoclass:: RangeCheckedConversion
 
 
-.. py:class:: RegularExpressionConversion(regex)
-
-  Conversion that checks that the input matches the regular expression
-  *regex*.  If it matches, returns the input, otherwise raises
-  :exc:`ValueError`.
+.. autoclass:: RegularExpressionConversion(regex)

--- a/doc/py-mod-loader.rst
+++ b/doc/py-mod-loader.rst
@@ -10,43 +10,15 @@ exported by the :mod:`ZConfig` package.  These classes may be useful
 for some applications, especially applications that want to use a
 non-default data type registry.
 
-.. py:class:: Resource(file, url, [,fragment])
-
-  Object that allows an open file object and a URL to be bound
-  together to ease handling.  Instances have the attributes
-  :attr:`file`, :attr:`url`, and :attr:`fragment` which store the
-  constructor arguments.  These objects also have a :meth:`close`
-  method which will call :meth:`~file.close` on *file*, then set the
-  :attr:`file` attribute to ``None`` and the :attr:`closed` attribute to
-  ``True``.
+.. autoclass:: Resource
 
 
-.. py:class:: BaseLoader
-
-  Base class for loader objects.  This should not be instantiated
-  directly, as the :meth:`loadResource` method must be overridden
-  for the instance to be used via the public API.
+.. autoclass:: ConfigLoader
+   :show-inheritance:
 
 
-
-.. py:class:: ConfigLoader(schema)
-
-  Loader for configuration files.  Each configuration file must
-  conform to the schema *schema*.  The ``load*()`` methods
-  return a tuple consisting of the configuration object and a
-  composite handler.
-
-
-
-
-.. py:class::  SchemaLoader(registry=None)
-
-  Loader that loads schema instances.  All schema loaded by a
-  :class:`SchemaLoader` will use the same data type registry.  If
-  *registry* is provided and not ``None``, it will be used,
-  otherwise an instance of :class:`ZConfig.datatypes.Registry` will be
-  used.
-
+.. autoclass:: SchemaLoader
+   :show-inheritance:
 
 
 Loader Objects
@@ -55,69 +27,28 @@ Loader Objects
 Loader objects provide a general public interface, an interface which
 subclasses must implement, and some utility methods.
 
+.. autoclass:: BaseLoader
+
+
 The following methods provide the public interface:
 
-.. py:method:: BaseLoader.loadURL(url)
-
-  Open and load a resource specified by the URL *url*.
-  This method uses the :meth:`loadResource` method to perform the
-  actual load, and returns whatever that method returns.
+.. automethod:: BaseLoader.loadURL
 
 
-.. py:method:: BaseLoader.loadFile(file, url=None)
-
-  Load from an open file object, *file*.  If given and not
-  ``None``, *url* should be the URL of the resource represented
-  by *file*.  If omitted or *None*, the ``name``
-  attribute of *file* is used to compute a ``file:`` URL, if
-  present.
-
-  This method uses the :meth:`loadResource` method to perform the
-  actual load, and returns whatever that method returns.
+.. automethod:: BaseLoader.loadFile
 
 
 The following method must be overridden by subclasses:
 
-.. py:method:: BaseLoader.loadResource(resource)
-
-  Subclasses of :class:`BaseLoader` must implement this method to
-  actually load the resource and return the appropriate
-  application-level object.
-
+.. automethod:: BaseLoader.loadResource
 
 
 The following methods can be used as utilities:
 
-.. py:method:: BaseLoader.isPath(s)
+.. automethod:: BaseLoader.isPath
 
-  Return true if *s* should be considered a filesystem path rather
-  than a URL.
+.. automethod:: BaseLoader.normalizeURL
 
+.. automethod:: BaseLoader.openResource
 
-.. py:method:: BaseLoader.normalizeURL(url-or-path)
-
-  Return a URL for *url-or-path*.  If *url-or-path* refers to
-  an existing file, the corresponding ``file:`` URL is returned.
-  Otherwise *url-or-path* is checked for sanity: if it
-  does not have a schema, :exc:`ValueError` is raised, and if it
-  does have a fragment identifier, :exc:`~.ConfigurationError` is
-  raised.
-
-  This uses :meth:`isPath` to determine whether *url-or-path*
-  is a URL of a filesystem path.
-
-
-.. py:method:: BaseLoader.openResource(url)
-
-  Returns a resource object that represents the URL *url*.  The
-  URL is opened using the :func:`urllib2.urlopen` function, and
-  the returned resource object is created using
-  :meth:`createResource`.  If the URL cannot be opened,
-  exc`ConfigurationError` is raised.
-
-
-.. py:method:: BaseLoader.createResource(file, url)
-
-  Returns a resource object for an open file and URL, given as
-  *file* and *url*, respectively.  This may be overridden by a
-  subclass if an alternate resource implementation is desired.
+.. automethod:: BaseLoader.createResource

--- a/doc/py-mod-subst.rst
+++ b/doc/py-mod-subst.rst
@@ -2,8 +2,7 @@
  ZConfig.substitution --- String substitution
 ==============================================
 
-.. py:module:: ZConfig.substitution
-  :synopsis: Shell-style string substitution helper.
+.. automodule:: ZConfig.substitution
 
 This module provides a basic substitution facility similar to that
 found in the Bourne shell (``sh`` on most UNIX platforms).
@@ -38,22 +37,10 @@ will always use a lower-case version of the name to perform the query.
 
 This module provides these functions:
 
-.. py:function:: substitute(s, mapping)
-
-  Substitute values from *mapping* into *s*.  *mapping*
-  can be a :class:`dict` or any type that supports the ``get()``
-  method of the mapping protocol.  Replacement
-  values are copied into the result without further interpretation.
-  Raises :exc:`~.SubstitutionSyntaxError` if there are malformed
-  constructs in *s*.
+.. autofunction:: substitute
 
 
-
-.. py:function:: isname(s)
-
-  Returns ``True`` if *s* is a valid name for a substitution
-  text, otherwise returns ``False``.
-
+.. autofunction:: isname
 
 
 Examples

--- a/doc/py-mod-zconfig.rst
+++ b/doc/py-mod-zconfig.rst
@@ -6,147 +6,48 @@
    :synopsis: Configuration package.
 
 
+Functions
+=========
+
 The main :mod:`ZConfig` package exports these convenience functions:
 
-.. py:function:: loadConfig(schema, url, [overrides])
+.. autofunction:: loadConfig
 
-  Load and return a configuration from a URL or pathname given by
-  *url*.  *url* may be a URL, absolute pathname, or relative
-  pathname.  Fragment identifiers are not supported.  *schema* is
-  a reference to a schema loaded by :func:`loadSchema` or
-  :func:`loadSchemaFile`.
+.. autofunction:: loadConfigFile
 
-  The return value is a tuple containing the configuration object and
-  a composite handler that, when called with a name-to-handler
-  mapping, calls all the handlers for the configuration.
+.. autofunction:: loadSchema
 
-  The optional *overrides* argument represents information derived
-  from command-line arguments.  If given, it must be either a sequence
-  of value specifiers, or ``None``.  A "value specifier" is a
-  string of the form ``optionpath=value``.  The
-  *optionpath* specifies the "full path" to the configuration
-  setting: it can contain a sequence of names, separated by
-  ``/`` characters. Each name before the last names a section
-  from the configuration file, and the last name corresponds to a key
-  within the section identified by the leading section names.  If
-  *optionpath* contains only one name, it identifies a key in the
-  top-level schema.  *value* is a string that will be treated
-  just like a value in the configuration file.
+.. autofunction:: loadSchemaFile
 
 
-.. py:function:: loadConfigFile(schema, file, [url, overrides])
-
-  Load and return a configuration from an opened file object.  If
-  *url* is omitted, one will be computed based on the
-  ``name`` attribute of *file*, if it exists.  If no URL can
-  be determined, all ``%include`` statements in the
-  configuration must use absolute URLs.  *schema* is a reference
-  to a schema loaded by :func:`loadSchema` or
-  :func:`loadSchemaFile`.
-
-  The return value is a tuple containing the configuration object and
-  a composite handler that, when called with a name-to-handler
-  mapping, calls all the handlers for the configuration.
-  The *overrides* argument is the same as for the
-  :func:`loadConfig` function.
-
-
-.. py:function:: loadSchema(url)
-
-  Load a schema definition from the URL *url*.
-  *url* may be a URL, absolute pathname, or relative pathname.
-  Fragment identifiers are not supported.
-
-  The resulting
-  schema object can be passed to :func:`loadConfig` or
-  :func:`loadConfigFile`.  The schema object may be used as many
-  times as needed.
-
-
-.. py:function:: loadSchemaFile(file, [url])
-
-  Load a schema definition from the open file object *file*.  If
-  *url* is given and not ``None``, it should be the URL of
-  resource represented by *file*.  If *url* is omitted or
-  ``None``, a URL may be computed from the ``name`` attribute
-  of *file*, if present.  The resulting schema object can
-  be passed to :func:`loadConfig` or :func:`loadConfigFile`.
-  The schema object may be used as many times as needed.
-
+Exceptions
+==========
 
 The following exceptions are defined by this package:
 
-.. py:exception:: ConfigurationError
-
-  Base class for exceptions specific to the :mod:`ZConfig` package.
-  All instances provide a ``message`` attribute that describes
-  the specific error, and a ``url`` attribute that gives the URL
-  of the resource the error was located in, or ``None``.
+.. autoexception:: ConfigurationError()
+   :show-inheritance:
 
 
-.. py:exception:: ConfigurationSyntaxError
-
-  Exception raised when a configuration source does not conform to the
-  allowed syntax.  In addition to the ``message`` and
-  ``url`` attributes, exceptions of this type offer the
-  ``lineno`` attribute, which provides the line number at which
-  the error was detected.
+.. autoexception:: ConfigurationSyntaxError()
 
 
-.. py:exception:: DataConversionError
-
-  Raised when a data type conversion fails with
-  :exc:`ValueError`.  This exception is a subclass of both
-  :exc:`ConfigurationError` and :exc:`ValueError`.  The
-  :func:`str` of the exception provides the explanation from the
-  original :exc:`ValueError`, and the line number and URL of the
-  value which provoked the error.  The following additional attributes
-  are provided:
+.. autoexception:: DataConversionError()
+   :show-inheritance:
 
 
-  =============    =============
-  Attribute        Value
-  =============    =============
-  ``colno``        column number at which the value starts, or ``None``
-  ``exception``    the original :exc:`ValueError` instance
-  ``lineno``       line number on which the value starts
-  ``message``      :func:`str` returned by the original :exc:`ValueError`
-  ``value``        original value passed to the conversion function
-  ``url``          URL of the resource providing the value text
-  =============    =============
+.. autoexception:: SchemaError()
 
 
-.. py:exception:: SchemaError
+.. autoexception:: SchemaResourceError()
+   :show-inheritance:
 
-  Raised when a schema contains an error.  This exception type
-  provides the attributes ``url``, ``lineno``, and
-  ``colno``, which provide the source URL, the line number, and
-  the column number at which the error was detected.  These attributes
-  may be ``None`` in some cases.
+.. autoexception:: SubstitutionReplacementError()
+   :show-inheritance:
 
-
-.. py:exception:: SchemaResourceError
-
-  Raised when there's an error locating a resource required by the
-  schema.  This is derived from :exc:`SchemaError`.  Instances of
-  this exception class add the attributes ``filename``,
-  ``package``, and ``path``, which hold the filename
-  searched for within the package being loaded, the name of the
-  package, and the ``__path__`` attribute of the package itself (or
-  ``None`` if it isn't a package or could not be imported).
+.. autoexception:: SubstitutionSyntaxError()
 
 
-.. py:exception:: SubstitutionReplacementError
-
-  Raised when the source text contains references to names which are
-  not defined in *mapping*.  The attributes ``source`` and
-  ``name`` provide the complete source text and the name
-  (converted to lower case) for which no replacement is defined.
-
-
-.. py:exception:: SubstitutionSyntaxError
-
-  Raised when the source text contains syntactical errors.
 
 .. _basic-usage:
 


### PR DESCRIPTION
This is helpful for keeping things in sync (I found a few signatures that were wrong) as well as online exploration at the REPL. I didn't document any previously-undocumented functions/methods/classes (there are a number of those in the datatypes package still).

There were also a small number of documented classes that were still old-style on Python 2 that I converted into new-style for consistency with Python 3 as I was adding their docstrings. I can back this out into a separate PR if desired.