### PR TITLE
Remove fallback for a missing 'logging' module

### DIFF
--- a/ZConfig/components/logger/__init__.py
+++ b/ZConfig/components/logger/__init__.py
@@ -12,12 +12,3 @@
 #
 ##############################################################################
 """ZConfig schema component package for logging configuration."""
-
-# Make sure we can't import this if "logging" isn't available; we
-# don't want partial imports to appear to succeed.
-
-try:
-    import logging
-except ImportError:
-    import sys
-    del sys.modules[__name__]


### PR DESCRIPTION
It's been part of the stdlib since 2.3.