### PR TITLE
Reach 100% code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = ZConfig

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,16 @@
 [run]
 source = ZConfig
+
+[report]
+# Coverage is run on Py2 and Py3
+# on POSIX platforms, so omit Windows-specific
+# things. Omit the main methods of test files.
+exclude_lines =
+    pragma: no cover
+    pragma no cover
+    class Win32
+    if os.name == 'nt':
+    if os.name == "nt":
+    if sys.platform == 'win32':
+    if __name__ == "__main__":
+    if __name__ == '__main__':

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,5 +12,6 @@ exclude_lines =
     if os.name == 'nt':
     if os.name == "nt":
     if sys.platform == 'win32':
+    if sys.platform\[:3\] == "win":
     if __name__ == "__main__":
     if __name__ == '__main__':

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,6 @@ source = ZConfig
 # things. Omit the main methods of test files.
 exclude_lines =
     pragma: no cover
-    pragma no cover
     class Win32
     if os.name == 'nt':
     if os.name == "nt":

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ develop-eggs/
 eggs/
 parts/
 doc/_build
+htmlcov/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy
-    - pypy3
+    - pypy-5.4.1
+    - pypy3.3-5.2-alpha1
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,20 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
     - pypy3
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py -q test -q
+    - coverage run setup.py -q test -q
 notifications:
     email: false
+after_success:
+    - coveralls
+
+cache: pip
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Change History for ZConfig
 
 - Host docs at https://zconfig.readthedocs.io
 
+- BaseLoader is now an abstract class that cannot be instantiated.
 
 3.1.0 (2015-10-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Change History for ZConfig
 3.2.0 (unreleased)
 ------------------
 
-- Drop support for Python 2.6 and 3.2.
+- Drop support for Python 2.6 and 3.2 and add support for Python 3.6.
 
 - Run tests with pypy and pypy3 as well.
 

--- a/ZConfig/__init__.py
+++ b/ZConfig/__init__.py
@@ -39,11 +39,7 @@ __version__ = ".".join([str(n) for n in version_info])
 from ZConfig.loader import loadConfig, loadConfigFile
 from ZConfig.loader import loadSchema, loadSchemaFile
 
-try:
-    import StringIO as StringIO
-except ImportError:
-    # Python 3 support.
-    import io as StringIO
+from ZConfig._compat import TextIO
 
 
 class ConfigurationError(Exception):
@@ -218,11 +214,12 @@ class SubstitutionReplacementError(ConfigurationSyntaxError, LookupError):
 
 def configureLoggers(text):
     """Configure one or more loggers from configuration text."""
-    schema = loadSchemaFile(StringIO.StringIO("""
+    schema = loadSchemaFile(TextIO("""
     <schema>
     <import package='ZConfig.components.logger'/>
     <multisection type='logger' name='*' attribute='loggers'/>
     </schema>
     """))
-    for factory in loadConfigFile(schema, StringIO.StringIO(text))[0].loggers:
+
+    for factory in loadConfigFile(schema, TextIO(text))[0].loggers:
         factory()

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -61,6 +61,7 @@ if PY3: # pragma: no cover
     exec_ = getattr(builtins, "exec")
     text_type = str
     binary_type = bytes
+    maxsize = sys.maxsize
 
     def reraise(tp, value, tb=None): #pragma NO COVER
         if value.__traceback__ is not tb:
@@ -70,6 +71,7 @@ if PY3: # pragma: no cover
 else: # pragma: no cover
     text_type = unicode
     binary_type = bytes
+    maxsize = sys.maxint
 
     def exec_(code, globs=None, locs=None): #pragma NO COVER
         """Execute code in a namespace."""

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -18,12 +18,12 @@ PY3 = sys.version_info[0] >= 3
 
 # Native string object IO
 if str is not bytes:
-    from io import StringIO as _NStringIO
+    from io import StringIO as NStringIO
 else:
     # Python 2
-    from io import BytesIO as _NStringIO
+    from io import BytesIO as NStringIO
 
-NStringIO = _NStringIO
+NStringIO = NStringIO
 
 from io import StringIO
 from io import BytesIO

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -89,6 +89,11 @@ else: # pragma: no cover
     raise tp, value, tb
 """)
 
-import abc
 
+def raise_with_same_tb(exception):
+	"Raise an exception having the current traceback (if there is one)"
+	reraise(type(exception), exception, sys.exc_info()[2])
+
+import abc
+# workaround the metaclass diff in Py2/Py3
 AbstractBaseClass = abc.ABCMeta('AbstractBaseClass', (object,), {})

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -40,10 +40,27 @@ except ImportError:
 
 urllib2 = urllib2
 
+try:
+    from urllib import pathname2url
+except ImportError:
+    # Python 3 support.
+    from urllib.request import pathname2url
+
+pathname2url = pathname2url
+
+try:
+    import urlparse as urlparse
+except ImportError:
+    # Python 3 support
+    import urllib.parse as urlparse
+
+urlparse = urlparse
+
 if PY3: # pragma: no cover
     import builtins
     exec_ = getattr(builtins, "exec")
-
+    text_type = str
+    binary_type = bytes
 
     def reraise(tp, value, tb=None): #pragma NO COVER
         if value.__traceback__ is not tb:
@@ -51,6 +68,9 @@ if PY3: # pragma: no cover
         raise value
 
 else: # pragma: no cover
+    text_type = unicode
+    binary_type = bytes
+
     def exec_(code, globs=None, locs=None): #pragma NO COVER
         """Execute code in a namespace."""
         if globs is None:

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -66,3 +66,7 @@ else: # pragma: no cover
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
+
+import abc
+
+AbstractBaseClass = abc.ABCMeta('AbstractBaseClass', (object,), {})

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -1,0 +1,68 @@
+##############################################################################
+#
+# Copyright (c) 2016 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import sys
+
+PY3 = sys.version_info[0] >= 3
+
+# Native string object IO
+if str is not bytes:
+    from io import StringIO as _NStringIO
+else:
+    # Python 2
+    from io import BytesIO as _NStringIO
+
+NStringIO = _NStringIO
+
+from io import StringIO
+from io import BytesIO
+
+def TextIO(text):
+    "Return StringIO or BytesIO as appropriate"
+    return BytesIO(text) if isinstance(text, bytes) else StringIO(text)
+
+try:
+    import urllib2
+except ImportError:
+    # Python 3 support.
+    import urllib.request as urllib2
+
+urllib2 = urllib2
+
+if PY3: # pragma: no cover
+    import builtins
+    exec_ = getattr(builtins, "exec")
+
+
+    def reraise(tp, value, tb=None): #pragma NO COVER
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+else: # pragma: no cover
+    def exec_(code, globs=None, locs=None): #pragma NO COVER
+        """Execute code in a namespace."""
+        if globs is None:
+            frame = sys._getframe(1)
+            globs = frame.f_globals
+            if locs is None:
+                locs = frame.f_locals
+            del frame
+        elif locs is None:
+            locs = globs
+        exec("""exec code in globs, locs""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")

--- a/ZConfig/cfgparser.py
+++ b/ZConfig/cfgparser.py
@@ -20,8 +20,8 @@ import ZConfig.url
 from ZConfig.substitution import isname, substitute
 from ZConfig._compat import reraise
 
-class ZConfigParser:
-    __metaclass__ = type
+class ZConfigParser(object):
+
     __slots__ = ('resource', 'context', 'lineno',
                  'stack', 'defines', 'file', 'url')
 
@@ -171,9 +171,7 @@ class ZConfigParser:
 
     def error(self, message):
         v = ZConfig.ConfigurationSyntaxError(message, self.url, self.lineno)
-        if sys.exc_info() and sys.exc_info()[2]:
-            reraise(type(v), v, sys.exc_info()[2])
-        raise v
+        reraise(type(v), v, sys.exc_info()[2])
 
     def _normalize_case(self, string):
         # This method is factored out solely to allow subclasses to modify

--- a/ZConfig/cfgparser.py
+++ b/ZConfig/cfgparser.py
@@ -18,7 +18,7 @@ import ZConfig
 import ZConfig.url
 
 from ZConfig.substitution import isname, substitute
-from ZConfig._compat import reraise
+from ZConfig._compat import raise_with_same_tb
 
 class ZConfigParser(object):
 
@@ -170,8 +170,10 @@ class ZConfigParser(object):
             raise
 
     def error(self, message):
-        v = ZConfig.ConfigurationSyntaxError(message, self.url, self.lineno)
-        reraise(type(v), v, sys.exc_info()[2])
+        raise_with_same_tb(
+            ZConfig.ConfigurationSyntaxError(
+                message, self.url, self.lineno))
+
 
     def _normalize_case(self, string):
         # This method is factored out solely to allow subclasses to modify

--- a/ZConfig/cmdline.py
+++ b/ZConfig/cmdline.py
@@ -30,7 +30,7 @@ import ZConfig
 import ZConfig.loader
 import ZConfig.matcher
 
-from ZConfig._compat import reraise
+from ZConfig._compat import raise_with_same_tb
 
 class ExtendedConfigLoader(ZConfig.loader.ConfigLoader):
     """A :class:`~.ConfigLoader` subclass that adds support for
@@ -118,9 +118,8 @@ class OptionBag(object):
         try:
             return self._basic_key(s)
         except ValueError as e:
-            e = ZConfig.ConfigurationSyntaxError(
-                "could not convert basic-key value: " + str(e), *pos)
-            reraise(type(e), e, sys.exc_info()[2])
+            raise_with_same_tb(ZConfig.ConfigurationSyntaxError(
+                "could not convert basic-key value: " + str(e), *pos))
 
     def add_value(self, name, val, pos):
         if name in self.keypairs:
@@ -185,8 +184,8 @@ class MatcherMixin(object):
         try:
             realkey = self.type.keytype(key)
         except ValueError as e:
-            dce = ZConfig.DataConversionError(e, key, position)
-            reraise(type(dce), dce, sys.exc_info()[2])
+            raise_with_same_tb(ZConfig.DataConversionError(e, key, position))
+
         if realkey in self.optionbag:
             return
         ZConfig.matcher.BaseMatcher.addValue(self, key, value, position)

--- a/ZConfig/components/logger/factory.py
+++ b/ZConfig/components/logger/factory.py
@@ -14,7 +14,11 @@
 
 _marker = object()
 
-class Factory:
+from abc import abstractmethod
+
+from ZConfig._compat import AbstractBaseClass
+
+class Factory(AbstractBaseClass):
     """Generic wrapper for instance construction.
 
     Calling the factory causes the instance to be created if it hasn't
@@ -32,5 +36,6 @@ class Factory:
             self.instance = self.create()
         return self.instance
 
+    @abstractmethod
     def create(self):
-        raise NotImplementedError("subclasses need to override create()")
+        "Subclasses must override create()"

--- a/ZConfig/components/logger/handlers.py
+++ b/ZConfig/components/logger/handlers.py
@@ -16,13 +16,9 @@
 from abc import abstractmethod
 import sys
 
-from ZConfig.components.logger.factory import Factory
+from ZConfig._compat import urlparse
 
-try:
-    import urlparse
-except ImportError:
-    # Python 3 support.
-    import urllib.parse as urlparse
+from ZConfig.components.logger.factory import Factory
 
 _log_format_variables = {
     'name': '',
@@ -94,7 +90,7 @@ class HandlerFactory(Factory):
         logger.setLevel(self.section.level)
         return logger
 
-    def getLevel(self):
+    def getLevel(self): # pragma: no cover Is this used?
         return self.section.level
 
 class FileHandlerFactory(HandlerFactory):
@@ -218,10 +214,6 @@ class SMTPHandlerFactory(HandlerFactory):
             mailhost = host, port
         kwargs = {}
         if self.section.smtp_username and self.section.smtp_password:
-            # Since credentials were only added in py2.6 we use a kwarg to not
-            # break compatibility with older py
-            if sys.version_info < (2, 6):
-                raise ValueError('SMTP auth requires at least Python 2.6.')
             kwargs['credentials'] = (self.section.smtp_username,
                                      self.section.smtp_password)
         elif (self.section.smtp_username or self.section.smtp_password):

--- a/ZConfig/components/logger/handlers.py
+++ b/ZConfig/components/logger/handlers.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """ZConfig factory datatypes for log handlers."""
 
+from abc import abstractmethod
 import sys
 
 from ZConfig.components.logger.factory import Factory
@@ -78,9 +79,9 @@ class HandlerFactory(Factory):
         Factory.__init__(self)
         self.section = section
 
+    @abstractmethod
     def create_loghandler(self):
-        raise NotImplementedError(
-            "subclasses must override create_loghandler()")
+        "subclasses must override create_loghandler()"
 
     def create(self):
         import logging

--- a/ZConfig/components/logger/loghandler.py
+++ b/ZConfig/components/logger/loghandler.py
@@ -14,7 +14,7 @@
 """Handlers which can plug into a PEP 282 logger."""
 
 import os
-import sys
+
 import weakref
 
 from logging import Handler, StreamHandler
@@ -25,6 +25,13 @@ from logging.handlers import SysLogHandler, BufferingHandler
 from logging.handlers import HTTPHandler, SMTPHandler
 from logging.handlers import NTEventLogHandler as Win32EventLogHandler
 
+# Export these, they're used in handlers.py
+SysLogHandler = SysLogHandler
+HTTPHandler = HTTPHandler
+SMTPHandler = SMTPHandler
+Win32EventLogHandler = Win32EventLogHandler
+
+from ZConfig._compat import maxsize
 
 
 _reopenable_handlers = []
@@ -162,7 +169,7 @@ class StartupHandler(BufferingHandler):
     """
 
     def __init__(self):
-        BufferingHandler.__init__(self, sys.maxint)
+        BufferingHandler.__init__(self, maxsize)
 
     def shouldFlush(self, record):
         return False

--- a/ZConfig/components/logger/loghandler.py
+++ b/ZConfig/components/logger/loghandler.py
@@ -79,7 +79,7 @@ class FileHandler(StreamHandler):
         # compromise.  :-(
         try:
             StreamHandler.close(self)
-        except KeyError:
+        except KeyError: # pragma: no cover
             pass
         _remove_from_reopenable(self._wr)
 

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -72,7 +72,7 @@ class LoggingTestHelper:
         for h in self._old_logger.handlers:
             self._old_logger.removeHandler(h)
         for h in self._old_handlers:
-            self._old_logger.addHandler(h)
+            self._old_logger.addHandler(h) # pragma: no cover
         self._old_logger.setLevel(self._old_level)
 
         while self._created:
@@ -205,24 +205,6 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
                                           "    path %s\n"
                                           "    level debug\n"
                                           "    when D\n"
-                                          "    old-files 11\n"
-                                          "  </logfile>\n"
-                                          "</eventlog>" % fn)
-        logfile = logger.handlers[0]
-        self.assertEqual(logfile.level, logging.DEBUG)
-        self.assertEqual(logfile.backupCount, 11)
-        self.assertEqual(logfile.interval, 86400)
-        self.assertTrue(isinstance(logfile, loghandler.TimedRotatingFileHandler))
-        logger.removeHandler(logfile)
-        logfile.close()
-
-    def test_with_timed_rotating_logfile(self):
-        fn = self.mktemp()
-        logger = self.check_simple_logger("<eventlog>\n"
-                                          "  <logfile>\n"
-                                          "    path %s\n"
-                                          "    level debug\n"
-                                          "    when D\n"
                                           "    interval 3\n"
                                           "    old-files 11\n"
                                           "  </logfile>\n"
@@ -311,7 +293,7 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
         syslog.close() # avoid ResourceWarning
         try:
             syslog.socket.close() # ResourceWarning under 3.2
-        except socket.SocketError:
+        except socket.SocketError: # pragma: no cover
             pass
 
     def test_with_http_logger_localhost(self):
@@ -362,30 +344,24 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
         self.assertEqual(handler.level, logging.FATAL)
 
     def test_with_email_notifier_with_credentials(self):
-        try:
-            logger = self.check_simple_logger("<eventlog>\n"
-                                              "  <email-notifier>\n"
-                                              "    to sysadmin@example.com\n"
-                                              "    from zlog-user@example.com\n"
-                                              "    level fatal\n"
-                                              "    smtp-username john\n"
-                                              "    smtp-password johnpw\n"
-                                              "  </email-notifier>\n"
-                                              "</eventlog>")
-        except ValueError:
-            if sys.version_info >= (2, 6):
-                # For python 2.6 no ValueError must be raised.
-                raise
-        else:
-            # This path must only be reached with python >=2.6
-            self.assertTrue(sys.version_info >= (2, 6))
-            handler = logger.handlers[0]
-            self.assertEqual(handler.toaddrs, ["sysadmin@example.com"])
-            self.assertEqual(handler.fromaddr, "zlog-user@example.com")
-            self.assertEqual(handler.fromaddr, "zlog-user@example.com")
-            self.assertEqual(handler.level, logging.FATAL)
-            self.assertEqual(handler.username, 'john')
-            self.assertEqual(handler.password, 'johnpw')
+        logger = self.check_simple_logger("<eventlog>\n"
+                                          "  <email-notifier>\n"
+                                          "    to sysadmin@example.com\n"
+                                          "    from zlog-user@example.com\n"
+                                          "    level fatal\n"
+                                          "    smtp-username john\n"
+                                          "    smtp-password johnpw\n"
+                                          "  </email-notifier>\n"
+                                          "</eventlog>")
+
+        self.assertTrue(sys.version_info >= (2, 6))
+        handler = logger.handlers[0]
+        self.assertEqual(handler.toaddrs, ["sysadmin@example.com"])
+        self.assertEqual(handler.fromaddr, "zlog-user@example.com")
+        self.assertEqual(handler.fromaddr, "zlog-user@example.com")
+        self.assertEqual(handler.level, logging.FATAL)
+        self.assertEqual(handler.username, 'john')
+        self.assertEqual(handler.password, 'johnpw')
 
     def test_with_email_notifier_with_invalid_credentials(self):
         self.assertRaises(ValueError,
@@ -469,17 +445,7 @@ class TestReopeningRotatingLogfiles(LoggingTestHelper, unittest.TestCase):
     def test_filehandler_reopen(self):
 
         def mkrecord(msg):
-            #
-            # Python 2.5.0 added an additional required argument to the
-            # LogRecord constructor, making it incompatible with prior
-            # versions.  Python 2.5.1 corrected the bug by making the
-            # additional argument optional.  We deal with 2.5.0 by adding
-            # the extra arg in only that case, using the default value
-            # from Python 2.5.1.
-            #
             args = ["foo.bar", logging.ERROR, __file__, 42, msg, (), ()]
-            if sys.version_info[:3] == (2, 5, 0):
-                args.append(None)
             return logging.LogRecord(*args)
 
         # This goes through the reopening operation *twice* to make

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -27,11 +27,7 @@ from ZConfig.components.logger import datatypes
 from ZConfig.components.logger import handlers
 from ZConfig.components.logger import loghandler
 
-try:
-    import StringIO as StringIO
-except ImportError:
-    # Python 3 support.
-    import io as StringIO
+from ZConfig._compat import NStringIO as StringIO
 
 class CustomFormatter(logging.Formatter):
     def formatException(self, ei):
@@ -40,7 +36,7 @@ class CustomFormatter(logging.Formatter):
         This adds helpful advice to the end of the traceback.
         """
         import traceback
-        sio = StringIO.StringIO()
+        sio = StringIO()
         traceback.print_exception(ei[0], ei[1], ei[2], file=sio)
         return sio.getvalue() + "... Don't panic!"
 
@@ -101,13 +97,13 @@ class LoggingTestHelper:
 
     def get_schema(self):
         if self._schema is None:
-            sio = StringIO.StringIO(self._schematext)
+            sio = StringIO(self._schematext)
             self.__class__._schema = ZConfig.loadSchemaFile(sio)
         return self._schema
 
     def get_config(self, text):
         conf, handler = ZConfig.loadConfigFile(self.get_schema(),
-                                               StringIO.StringIO(text))
+                                               StringIO(text))
         self.assertTrue(not handler)
         return conf
 
@@ -268,7 +264,7 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
         # The factory has already been created; make sure it picks up
         # the stderr we set here when we create the logger and
         # handlers:
-        sio = StringIO.StringIO()
+        sio = StringIO()
         setattr(sys, name, sio)
         try:
             logger = conf.eventlog()
@@ -288,7 +284,7 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
         </logfile>
         </eventlog>
         """)
-        sio = StringIO.StringIO()
+        sio = StringIO()
         sys.stdout = sio
         try:
             logger = conf.eventlog()

--- a/ZConfig/datatypes.py
+++ b/ZConfig/datatypes.py
@@ -34,6 +34,9 @@ import re
 import sys
 import datetime
 
+from ZConfig._compat import text_type
+from ZConfig._compat import binary_type
+
 try:
     unicode
 except NameError:
@@ -277,13 +280,10 @@ class SocketConnectionAddress(SocketAddress):
 
 
 def float_conversion(v):
-    try:
-        is_str = isinstance(v, basestring)
-    except NameError:
-        # Python 3 support.
-        is_str = isinstance(v, str)
+    # float() will accept both bytes and unicode on both 2 and 3
+    is_str = isinstance(v, text_type) or isinstance(v, binary_type)
     if is_str:
-        if v.lower() in ["inf", "-inf", "nan"]:
+        if v.lower() in (u"inf", u"-inf", u"nan", b'inf', b'-inf', b'nan'):
             raise ValueError(repr(v) + " is not a portable float representation")
     return float(v)
 

--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -20,8 +20,7 @@ from abc import abstractmethod
 
 from ZConfig._compat import AbstractBaseClass
 
-class UnboundedThing:
-    __metaclass__ = type # XXX Python 3
+class UnboundedThing(object):
     __slots__ = ()
 
     def __lt__(self, other):
@@ -48,8 +47,7 @@ class UnboundedThing:
 Unbounded = UnboundedThing()
 
 
-class ValueInfo:
-    __metaclass__ = type # XXX Python 3
+class ValueInfo(object):
     __slots__ = 'value', 'position'
 
     def __init__(self, value, position):

--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -16,9 +16,12 @@
 import copy
 import ZConfig
 
+from abc import abstractmethod
+
+from ZConfig._compat import AbstractBaseClass
 
 class UnboundedThing:
-    __metaclass__ = type
+    __metaclass__ = type # XXX Python 3
     __slots__ = ()
 
     def __lt__(self, other):
@@ -46,7 +49,7 @@ Unbounded = UnboundedThing()
 
 
 class ValueInfo:
-    __metaclass__ = type
+    __metaclass__ = type # XXX Python 3
     __slots__ = 'value', 'position'
 
     def __init__(self, value, position):
@@ -61,7 +64,7 @@ class ValueInfo:
             raise ZConfig.DataConversionError(e, self.value, self.position)
 
 
-class BaseInfo:
+class BaseInfo(AbstractBaseClass):
     """Information about a single configuration key."""
 
     description = None
@@ -128,6 +131,7 @@ class BaseKeyInfo(BaseInfo):
                 "unexpected key for default value")
         self.add_valueinfo(ValueInfo(value, position), key)
 
+    @abstractmethod
     def add_valueinfo(self, vi, key):
         """Actually add a ValueInfo to this key-info object.
 
@@ -138,8 +142,6 @@ class BaseKeyInfo(BaseInfo):
         This method is a requirement for subclasses, and should not be
         called by client code.
         """
-        raise NotImplementedError(
-            "add_valueinfo() must be implemented by subclasses of BaseKeyInfo")
 
     def prepare_raw_defaults(self):
         assert self.name == "+"

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -213,7 +213,7 @@ class BaseLoader(AbstractBaseClass):
             except urllib2.URLError as e:
                 # urllib2.URLError has a particularly hostile str(), so we
                 # generally don't want to pass it along to the user.
-                self._raise_open_error(url, e.reason)
+                self._raise_open_error(url, e.reason) # pragma: no cover
             except (IOError, OSError) as e:
                 # Python 2.1 raises a different error from Python 2.2+,
                 # so we catch both to make sure we detect the situation.
@@ -239,9 +239,11 @@ class BaseLoader(AbstractBaseClass):
         else:
             what = "URL"
             ident = url
-        raise ZConfig.ConfigurationError(
+        error = ZConfig.ConfigurationError(
             "error opening %s %s: %s" % (what, ident, message),
             url)
+
+        reraise(type(error), error, sys.exc_info()[2])
 
     def normalizeURL(self, url):
         """Return a URL for *url*
@@ -367,7 +369,7 @@ class SchemaLoader(BaseLoader):
 
     def schemaComponentSource(self, package, file):
         parts = package.split(".")
-        if not parts:
+        if not parts: # pragma: no cover. can we even get here?
             raise ZConfig.SchemaError(
                 "illegal schema component name: " + repr(package))
         if "" in parts:

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -29,6 +29,7 @@ import ZConfig.schema
 import ZConfig.url
 
 from ZConfig._compat import reraise
+from ZConfig._compat import raise_with_same_tb
 from ZConfig._compat import urllib2
 from ZConfig._compat import AbstractBaseClass
 from ZConfig._compat import pathname2url
@@ -242,8 +243,7 @@ class BaseLoader(AbstractBaseClass):
         error = ZConfig.ConfigurationError(
             "error opening %s %s: %s" % (what, ident, message),
             url)
-
-        reraise(type(error), error, sys.exc_info()[2])
+        raise_with_same_tb(error)
 
     def normalizeURL(self, url):
         """Return a URL for *url*

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -31,12 +31,7 @@ import ZConfig.url
 from ZConfig._compat import reraise
 from ZConfig._compat import urllib2
 from ZConfig._compat import AbstractBaseClass
-
-try:
-    from urllib import pathname2url
-except ImportError:
-    # Python 3 support
-    from urllib.request import pathname2url
+from ZConfig._compat import pathname2url
 
 
 def loadSchema(url):

--- a/ZConfig/loader.py
+++ b/ZConfig/loader.py
@@ -17,6 +17,7 @@ import os.path
 import re
 import sys
 
+from abc import abstractmethod
 from io import StringIO
 
 import ZConfig
@@ -29,6 +30,7 @@ import ZConfig.url
 
 from ZConfig._compat import reraise
 from ZConfig._compat import urllib2
+from ZConfig._compat import AbstractBaseClass
 
 try:
     from urllib import pathname2url
@@ -128,7 +130,7 @@ def _get_config_loader(schema, overrides):
     return loader
 
 
-class BaseLoader(object):
+class BaseLoader(AbstractBaseClass):
     """Base class for loader objects.
 
     This should not be instantiated
@@ -182,6 +184,7 @@ class BaseLoader(object):
 
     # utilities
 
+    @abstractmethod
     def loadResource(self, resource):
         """Abstract method.
 
@@ -189,8 +192,6 @@ class BaseLoader(object):
         actually load the resource and return the appropriate
         application-level object.
         """
-        raise NotImplementedError(
-            "BaseLoader.loadResource() must be overridden by a subclass")
 
     def openResource(self, url):
         """Returns a resource object that represents the URL *url*.

--- a/ZConfig/matcher.py
+++ b/ZConfig/matcher.py
@@ -18,7 +18,7 @@ import sys
 import ZConfig
 
 from ZConfig.info import ValueInfo
-from ZConfig._compat import reraise
+from ZConfig._compat import raise_with_same_tb
 
 
 class BaseMatcher(object):
@@ -191,9 +191,9 @@ class BaseMatcher(object):
                             try:
                                 s = st.datatype(s)
                             except ValueError as e:
-                                dce = ZConfig.DataConversionError(
-                                    e, s, (-1, -1, None))
-                                reraise(type(dce), dce, sys.exc_info()[2])
+                                raise_with_same_tb(ZConfig.DataConversionError(
+                                    e, s, (-1, -1, None)))
+
                         v.append(s)
                 elif ci.name == '+':
                     v = values[attr]
@@ -207,9 +207,9 @@ class BaseMatcher(object):
                     try:
                         v = st.datatype(values[attr])
                     except ValueError as e:
-                        dce = ZConfig.DataConversionError(
-                            e, values[attr], (-1, -1, None))
-                        reraise(type(dce), dce, sys.exc_info()[2])
+                        raise_with_same_tb(ZConfig.DataConversionError(
+                            e, values[attr], (-1, -1, None)))
+
                 else:
                     v = None
             elif name == '+':

--- a/ZConfig/matcher.py
+++ b/ZConfig/matcher.py
@@ -13,9 +13,12 @@
 ##############################################################################
 """Utility that manages the binding of configuration data to a section."""
 
+import sys
+
 import ZConfig
 
 from ZConfig.info import ValueInfo
+from ZConfig._compat import reraise
 
 
 class BaseMatcher(object):
@@ -33,9 +36,7 @@ class BaseMatcher(object):
             assert info.attribute is not None
             self._values[info.attribute] = v
         self._sectionnames = {}
-        if handlers is None:
-            handlers = []
-        self.handlers = handlers
+        self.handlers = handlers if handlers is not None else []
 
     def __repr__(self):
         clsname = self.__class__.__name__
@@ -56,7 +57,7 @@ class BaseMatcher(object):
             v.append(sectvalue)
         elif v is None:
             self._values[attr] = sectvalue
-        else:
+        else: # pragma: no cover
             raise ZConfig.ConfigurationError(
                 "too many instances of %s section" % repr(ci.sectiontype.name))
 
@@ -77,7 +78,7 @@ class BaseMatcher(object):
                 raise ZConfig.ConfigurationError(
                     repr(key) + " is not a known key name")
             k, ci = arbkey_info
-        if ci.issection():
+        if ci.issection(): # pragma: no cover
             if ci.name:
                 extra = " in %s sections" % repr(self.type.name)
             else:
@@ -91,17 +92,20 @@ class BaseMatcher(object):
         v = self._values[attr]
         if v is None:
             if k == '+':
-                v = {}
+                v = {} # pragma: no cover
             elif ismulti:
-                v = []
+                v = [] # pragma: no cover
             self._values[attr] = v
         elif not ismulti:
             if k != '+':
                 raise ZConfig.ConfigurationError(
                     repr(key) + " does not support multiple values")
-        elif len(v) == ci.maxOccurs:
+        elif len(v) == ci.maxOccurs: # pragma: no cover
+            # This code may be impossible to hit. Previously it would
+            # have raised a NameError because it used an unbound
+            # local.
             raise ZConfig.ConfigurationError(
-                "too many values for " + repr(name))
+                "too many values for " + repr(ci))
 
         value = ValueInfo(value, position)
         if k == '+':
@@ -111,7 +115,7 @@ class BaseMatcher(object):
                 else:
                     v[realkey] = [value]
             else:
-                if realkey in v:
+                if realkey in v: # pragma: no cover
                     raise ZConfig.ConfigurationError(
                         "too many values for " + repr(key))
                 v[realkey] = value
@@ -153,7 +157,7 @@ class BaseMatcher(object):
                     raise ZConfig.ConfigurationError(
                         "no values for %s; %s required" % (key, ci.minOccurs))
                 else:
-                    v = values[attr] = default[:]
+                    v = values[attr] = default[:] # pragma: no cover
             if ci.ismulti():
                 if not v:
                     default = ci.getdefault()
@@ -167,7 +171,7 @@ class BaseMatcher(object):
                         % (key, len(v), ci.minOccurs))
             if v is None and not ci.issection():
                 if ci.ismulti():
-                    v = ci.getdefault()[:]
+                    v = ci.getdefault()[:] # pragma: no cover
                 else:
                     v = ci.getdefault()
                 values[attr] = v
@@ -187,8 +191,9 @@ class BaseMatcher(object):
                             try:
                                 s = st.datatype(s)
                             except ValueError as e:
-                                raise ZConfig.DataConversionError(
+                                dce = ZConfig.DataConversionError(
                                     e, s, (-1, -1, None))
+                                reraise(type(dce), dce, sys.exc_info()[2])
                         v.append(s)
                 elif ci.name == '+':
                     v = values[attr]
@@ -202,8 +207,9 @@ class BaseMatcher(object):
                     try:
                         v = st.datatype(values[attr])
                     except ValueError as e:
-                        raise ZConfig.DataConversionError(
+                        dce = ZConfig.DataConversionError(
                             e, values[attr], (-1, -1, None))
+                        reraise(type(dce), dce, sys.exc_info()[2])
                 else:
                     v = None
             elif name == '+':

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -22,10 +22,8 @@ import ZConfig
 from ZConfig import info
 from ZConfig import url
 
-try:
-    BLANK = unicode('')
-except NameError:
-    BLANK = ''
+BLANK = u''
+
 
 def parseResource(resource, loader):
     parser = SchemaParser(loader, resource.url)

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -22,7 +22,7 @@ import ZConfig
 from ZConfig import info
 from ZConfig import url
 
-from ZConfig._compat import reraise
+from ZConfig._compat import raise_with_same_tb
 
 BLANK = u''
 
@@ -469,8 +469,7 @@ class BaseParser(xml.sax.ContentHandler):
         return e
 
     def error(self, message):
-        e = self.initerror(ZConfig.SchemaError(message))
-        reraise(type(e), e, sys.exc_info()[2])
+        raise_with_same_tb(self.initerror(ZConfig.SchemaError(message)))
 
 
 class SchemaParser(BaseParser):

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -451,13 +451,13 @@ class BaseParser(xml.sax.ContentHandler):
         try:
             return self._basic_key(s)
         except ValueError as e:
-            self.error(e[0])
+            self.error(str(e))
 
     def identifier(self, s):
         try:
             return self._identifier(s)
         except ValueError as e:
-            self.error(e[0])
+            self.error(str(e))
 
     # exception setup helpers
 

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -22,8 +22,9 @@ import ZConfig
 from ZConfig import info
 from ZConfig import url
 
-BLANK = u''
+from ZConfig._compat import reraise
 
+BLANK = u''
 
 def parseResource(resource, loader):
     parser = SchemaParser(loader, resource.url)
@@ -95,19 +96,24 @@ class BaseParser(xml.sax.ContentHandler):
                            % (_srepr(name), _srepr(parent)))
         elif name != self._top_level:
             self.error("Unknown document type " + name)
+
         self._elem_stack.append(name)
+
+        # self._schema is assigned to in self.start_<_top_level>, so
+        # most of the checks for it being None are just extra precaution.
         if name == self._top_level:
-            if self._schema is not None:
+            if self._schema is not None: # pragma: no cover
                 self.error("schema element improperly nested")
             getattr(self, "start_" + name)(attrs)
         elif name in self._handled_tags:
-            if self._schema is None:
+            if self._schema is None: # pragma: no cover
                 self.error(name + " element outside of schema")
             getattr(self, "start_" + name)(attrs)
         elif name in self._cdata_tags:
-            if self._schema is None:
+            if self._schema is None: # pragma: no cover
                 self.error(name + " element outside of schema")
-            if self._cdata is not None:
+            if self._cdata is not None: # pragma: no cover
+                # this should be handled by the earliel nesting check
                 self.error(name + " element improperly nested")
             self._cdata = []
             self._position = None
@@ -132,7 +138,8 @@ class BaseParser(xml.sax.ContentHandler):
             getattr(self, "characters_" + name)(data)
 
     def endDocument(self):
-        if self._schema is None:
+        if self._schema is None: # pragma: no cover
+            # this would have to be a broken subclass
             self.error("no %s found" % self._top_level)
 
     # helper methods
@@ -142,7 +149,7 @@ class BaseParser(xml.sax.ContentHandler):
             return (self._locator.getLineNumber(),
                     self._locator.getColumnNumber(),
                     (self._locator.getSystemId() or self._url))
-        else:
+        else: # pragma: no cover
             return None, None, self._url
 
     def get_handler(self, attrs):
@@ -232,7 +239,8 @@ class BaseParser(xml.sax.ContentHandler):
         any, name, attribute = self.get_name_info(attrs, element)
         if any == '*':
             self.error(element + " may not specify '*' for name")
-        if not name and any != '+':
+        if not name and any != '+': # pragma: no cover
+            # Con we even get here?
             self.error(element + " name may not be omitted or empty")
         datatype = self.get_datatype(attrs, "datatype", "string")
         handler = self.get_handler(attrs)
@@ -300,7 +308,7 @@ class BaseParser(xml.sax.ContentHandler):
             src = url.urljoin(self._url, src)
             src, fragment = url.urldefrag(src)
             if fragment:
-                self.error("import src many not include"
+                self.error("import src may not include"
                            " a fragment identifier")
             schema = self._loader.loadURL(src)
             for n in schema.gettypenames():
@@ -361,7 +369,8 @@ class BaseParser(xml.sax.ContentHandler):
         handler = self.get_handler(attrs)
         min = self.get_required(attrs) and 1 or 0
         any, name, attribute = self.get_name_info(attrs, "section", "*")
-        if any and not attribute:
+        if any and not attribute: # pragma: no cover
+            # It seems like this is handled by get_name_info.
             self.error(
                 "attribute must be specified if section name is '*' or '+'")
         section = info.SectionInfo(any or name, sectiontype,
@@ -460,7 +469,8 @@ class BaseParser(xml.sax.ContentHandler):
         return e
 
     def error(self, message):
-        raise self.initerror(ZConfig.SchemaError(message))
+        e = self.initerror(ZConfig.SchemaError(message))
+        reraise(type(e), e, sys.exc_info()[2])
 
 
 class SchemaParser(BaseParser):
@@ -593,6 +603,9 @@ class ComponentParser(BaseParser):
         self.pop_prefix()
 
     def _check_not_toplevel(self, what):
-        if not self._stack:
+        if not self._stack: # pragma: no cover
+            # we can't get here because the elements that call
+            # this function have specified _allowed_parents that are
+            # checked first
             self.error("cannot define top-level %s in a schema %s"
                        % (what, self._top_level))

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -113,7 +113,7 @@ class BaseParser(xml.sax.ContentHandler):
             if self._schema is None: # pragma: no cover
                 self.error(name + " element outside of schema")
             if self._cdata is not None: # pragma: no cover
-                # this should be handled by the earliel nesting check
+                # this should be handled by the earlier nesting check
                 self.error(name + " element improperly nested")
             self._cdata = []
             self._position = None
@@ -240,7 +240,7 @@ class BaseParser(xml.sax.ContentHandler):
         if any == '*':
             self.error(element + " may not specify '*' for name")
         if not name and any != '+': # pragma: no cover
-            # Con we even get here?
+            # Can we even get here?
             self.error(element + " name may not be omitted or empty")
         datatype = self.get_datatype(attrs, "datatype", "string")
         handler = self.get_handler(attrs)

--- a/ZConfig/schemaless.py
+++ b/ZConfig/schemaless.py
@@ -26,7 +26,7 @@ def loadConfigFile(file, url=None):
     return c.top
 
 
-class Resource:
+class Resource(object):
 
     def __init__(self, file, url=''):
         self.file, self.url = file, url

--- a/ZConfig/schemaless.py
+++ b/ZConfig/schemaless.py
@@ -75,7 +75,7 @@ class Section(dict):
 
         for section in self.sections:
             result.append(section.__str__(pre))
-        
+
         if self.type:
             pre = pre[:-2]
             result.append('%s</%s>' % (pre, self.type))
@@ -87,7 +87,7 @@ class Section(dict):
         return result
 
 
-class Context:
+class Context(object):
 
     def __init__(self):
         self.top = Section()

--- a/ZConfig/schemaless.txt
+++ b/ZConfig/schemaless.txt
@@ -46,12 +46,8 @@ open for reading.  Let's take a look at this, and what it returns::
   ...
   ... '''
 
-  >>> try:
-  ...     import StringIO
-  ... except ImportError:
-  ...     import io as StringIO
-
-  >>> config = schemaless.loadConfigFile(StringIO.StringIO(config_text))
+  >>> from ZConfig._compat import NStringIO as StringIO
+  >>> config = schemaless.loadConfigFile(StringIO(config_text))
 
 The `config` object is a mapping from top-level keys to lists of
 values::
@@ -200,7 +196,7 @@ other elements of a configuration are::
   ...
   ... '''
 
-  >>> config = schemaless.loadConfigFile(StringIO.StringIO(config_text))
+  >>> config = schemaless.loadConfigFile(StringIO(config_text))
 
   >>> print(config)
   %import some.package
@@ -231,7 +227,7 @@ Multiple imports of the same name are removed::
   ...
   ... '''
 
-  >>> config = schemaless.loadConfigFile(StringIO.StringIO(config_text))
+  >>> config = schemaless.loadConfigFile(StringIO(config_text))
 
   >>> print(config)
   %import some.package
@@ -280,7 +276,7 @@ raised when loading the configuration::
   ...
   ... '''
 
-  >>> schemaless.loadConfigFile(StringIO.StringIO(config_text))
+  >>> schemaless.loadConfigFile(StringIO(config_text))
   Traceback (most recent call last):
   NotImplementedError: defines are not supported
 
@@ -292,6 +288,6 @@ A similar exception is raised for %include::
   ...
   ... '''
 
-  >>> schemaless.loadConfigFile(StringIO.StringIO(config_text))
+  >>> schemaless.loadConfigFile(StringIO(config_text))
   Traceback (most recent call last):
   NotImplementedError: includes are not supported

--- a/ZConfig/tests/bad-component.xml
+++ b/ZConfig/tests/bad-component.xml
@@ -1,0 +1,5 @@
+<component>
+
+  <section />
+
+</component>

--- a/ZConfig/tests/bad-component2.xml
+++ b/ZConfig/tests/bad-component2.xml
@@ -1,0 +1,7 @@
+<component>
+
+    <sectiontype name='foo'>
+        <section type='foo' attribute='bar' />
+    </sectiontype>
+
+</component>

--- a/ZConfig/tests/input/simplesections.xml
+++ b/ZConfig/tests/input/simplesections.xml
@@ -10,9 +10,14 @@
     <key name="var" />
   </sectiontype>
 
+  <sectiontype name="hasmin">
+    <key name="var" required="yes" />
+  </sectiontype>
+
   <multisection type="section" name="*" attribute="sections" />
   <section type="minimal" name="*" attribute="minimal" />
   <section type="trivial" name="*" attribute="trivial" />
+  <section type="hasmin" name="+" attribute="hasmin" />
 
   <key name="var" />
   <key name="var-0" />

--- a/ZConfig/tests/support.py
+++ b/ZConfig/tests/support.py
@@ -22,16 +22,11 @@ from ZConfig.loader import ConfigLoader
 from ZConfig.url import urljoin
 
 from ZConfig._compat import NStringIO as StringIO
-
-try:
-    from urllib import pathname2url
-except ImportError:
-    # Python 3 support.
-    from urllib.request import pathname2url
+from ZConfig._compat import pathname2url
 
 try:
     __file__
-except NameError:
+except NameError: # pragma: no cover
     import sys
     __file__ = sys.argv[0]
 

--- a/ZConfig/tests/support.py
+++ b/ZConfig/tests/support.py
@@ -21,11 +21,7 @@ import ZConfig
 from ZConfig.loader import ConfigLoader
 from ZConfig.url import urljoin
 
-try:
-    import StringIO
-except ImportError:
-    # Python 3 support.
-    import io as StringIO
+from ZConfig._compat import NStringIO as StringIO
 
 try:
     from urllib import pathname2url
@@ -61,7 +57,7 @@ class TestHelper:
         return self.schema
 
     def load_schema_text(self, text, url=None):
-        sio = StringIO.StringIO(text)
+        sio = StringIO(text)
         self.schema = ZConfig.loadSchemaFile(sio, url)
         return self.schema
 
@@ -73,7 +69,7 @@ class TestHelper:
         return self.conf
 
     def load_config_text(self, schema, text, num_handlers=0, url=None):
-        sio = StringIO.StringIO(text)
+        sio = StringIO(text)
         loader = self.create_config_loader(schema)
         self.conf, self.handlers = loader.loadFile(sio, url)
         self.assertEqual(len(self.handlers), num_handlers)

--- a/ZConfig/tests/test_cfgimports.py
+++ b/ZConfig/tests/test_cfgimports.py
@@ -18,12 +18,7 @@ import unittest
 import ZConfig
 import ZConfig.tests.support
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    # Python 3 support.
-    from io import StringIO
-
+from ZConfig._compat import NStringIO as StringIO
 
 class TestImportFromConfiguration(
     ZConfig.tests.support.TestHelper, unittest.TestCase):

--- a/ZConfig/tests/test_config.py
+++ b/ZConfig/tests/test_config.py
@@ -210,7 +210,7 @@ class ConfigurationTestCase(unittest.TestCase):
                                 'malformed section start',
                                 self.loadtext, '<section')
 
-        # ConfigLoader.endSection raises this and its recaught and changed to a
+        # ConfigLoader.endSection raises this and it is recaught and changed to a
         # SyntaxError
         self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
                                 "no values for",

--- a/ZConfig/tests/test_config.py
+++ b/ZConfig/tests/test_config.py
@@ -20,11 +20,7 @@ import ZConfig
 
 from ZConfig.tests.support import CONFIG_BASE
 
-try:
-    import StringIO as StringIO
-except ImportError:
-    # Python 3 support.
-    import io as StringIO
+from ZConfig._compat import NStringIO as StringIO
 
 class ConfigurationTestCase(unittest.TestCase):
 
@@ -47,7 +43,7 @@ class ConfigurationTestCase(unittest.TestCase):
         return conf
 
     def loadtext(self, text):
-        sio = StringIO.StringIO(text)
+        sio = StringIO(text)
         return self.loadfile(sio)
 
     def loadfile(self, file):
@@ -112,7 +108,7 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertEqual(conf.var4, "value")
 
     def test_includes_with_defines(self):
-        self.schema = ZConfig.loadSchemaFile(StringIO.StringIO("""\
+        self.schema = ZConfig.loadSchemaFile(StringIO("""\
             <schema>
               <key name='refinner' />
               <key name='refouter' />
@@ -145,8 +141,8 @@ class ConfigurationTestCase(unittest.TestCase):
                           self.load, "simplesections.conf#another")
 
     def test_load_from_fileobj(self):
-        sio = StringIO.StringIO("%define name value\n"
-                                "getname x $name y \n")
+        sio = StringIO("%define name value\n"
+                       "getname x $name y \n")
         cf = self.loadfile(sio)
         self.assertEqual(cf.getname, "x value y")
 

--- a/ZConfig/tests/test_datatypes.py
+++ b/ZConfig/tests/test_datatypes.py
@@ -258,7 +258,7 @@ class DatatypeTestCase(unittest.TestCase):
         AF_INET6 = socket.AF_INET6
         defhost = ZConfig.datatypes.DEFAULT_HOST
 
-        def check(value, family, address, self=self, convert=convert):
+        def check(value, family, address):
             a = convert(value)
             self.assertEqual(a.family, family)
             self.assertEqual(a.address, address)
@@ -279,6 +279,12 @@ class DatatypeTestCase(unittest.TestCase):
         else: # pragma: no cover
             self.assertTrue(a1.family is None)
             self.assertTrue(a2.family is None)
+
+        convert = self.types.get('socket-binding-address')
+        check(":80",                 AF_INET, (defhost, 80))
+
+        convert = self.types.get('socket-connection-address')
+        check(":80",                 AF_INET, ("127.0.0.1", 80))
 
     def test_ipaddr_or_hostname(self):
         convert = self.types.get('ipaddr-or-hostname')
@@ -380,6 +386,7 @@ class DatatypeTestCase(unittest.TestCase):
         eq(convert('4w 2d 7h 12m 14s'),
            datetime.timedelta(2, 14, minutes=12, hours=7, weeks=4))
 
+        raises(TypeError, convert, '1y')
 
 class RegistryTestCase(unittest.TestCase):
 
@@ -400,6 +407,29 @@ class RegistryTestCase(unittest.TestCase):
             shutil.rmtree(tmpdir)
             sys.path[:] = old_sys_path
         self.assertEqual(datatype, 42)
+
+
+    def test_register_shadow(self):
+        reg = ZConfig.datatypes.Registry()
+        self.assertRaisesRegexp(ValueError,
+                                "conflicts with built-in type",
+                                reg.register,
+                                'integer', None)
+
+        reg.register("foobar", None)
+        self.assertRaisesRegexp(ValueError,
+                                "already registered",
+                                reg.register,
+                                'foobar', None)
+
+    def test_get_fallback_basic_key(self):
+        reg = ZConfig.datatypes.Registry({})
+        self.assertIsNone(reg._basic_key)
+        self.assertRaisesRegexp(ValueError,
+                                "unloadable datatype name",
+                                reg.get,
+                                'integer')
+        self.assertIsNotNone(reg._basic_key)
 
 TEST_DATATYPE_SOURCE = """
 # sample datatypes file

--- a/ZConfig/tests/test_datatypes.py
+++ b/ZConfig/tests/test_datatypes.py
@@ -25,7 +25,7 @@ import ZConfig.datatypes
 
 try:
     here = __file__
-except NameError:
+except NameError: # pragma: no cover
     here = sys.argv[0]
 
 here = os.path.abspath(here)
@@ -93,14 +93,13 @@ class DatatypeTestCase(unittest.TestCase):
 
         # These are not portable representations; make sure they are
         # disallowed everywhere for consistency.
-        raises(ValueError, convert, "inf")
-        raises(ValueError, convert, "-inf")
-        raises(ValueError, convert, "nan")
+        raises(ValueError, convert, b"inf")
+        raises(ValueError, convert, b"-inf")
+        raises(ValueError, convert, b"nan")
 
-        if have_unicode:
-            raises(ValueError, convert, unicode("inf"))
-            raises(ValueError, convert, unicode("-inf"))
-            raises(ValueError, convert, unicode("nan"))
+        raises(ValueError, convert, u"inf")
+        raises(ValueError, convert, u"-inf")
+        raises(ValueError, convert, u"nan")
 
     def test_datatype_identifier(self):
         convert = self.types.get("identifier")
@@ -277,7 +276,7 @@ class DatatypeTestCase(unittest.TestCase):
         if hasattr(socket, "AF_UNIX"):
             self.assertEqual(a1.family, socket.AF_UNIX)
             self.assertEqual(a2.family, socket.AF_UNIX)
-        else:
+        else: # pragma: no cover
             self.assertTrue(a1.family is None)
             self.assertTrue(a2.family is None)
 

--- a/ZConfig/tests/test_info.py
+++ b/ZConfig/tests/test_info.py
@@ -71,7 +71,7 @@ class BaseKeyInfoTestCase(InfoMixin, unittest.TestCase):
 
     class Class(BaseKeyInfo):
         def add_valueinfo(self, vi, key):
-            pass
+            "This wont actually be called"
 
     def test_cant_instantiate(self):
         self.Class = BaseKeyInfo

--- a/ZConfig/tests/test_info.py
+++ b/ZConfig/tests/test_info.py
@@ -1,0 +1,229 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+
+import ZConfig
+from ZConfig import SchemaError
+from ZConfig import ConfigurationError
+
+from ZConfig.info import Unbounded
+from ZConfig.info import BaseInfo
+from ZConfig.info import BaseKeyInfo
+from ZConfig.info import KeyInfo
+from ZConfig.info import SectionInfo
+from ZConfig.info import AbstractType
+from ZConfig.info import SectionType
+from ZConfig.info import SchemaType
+
+class UnboundTestCase(unittest.TestCase):
+
+    def test_order(self):
+        self.assertGreater(Unbounded, self)
+        self.assertFalse(Unbounded > Unbounded)
+        self.assertEqual(Unbounded, Unbounded)
+
+class InfoMixin(object):
+
+    Class = None
+
+    default_kwargs = {'name': '', 'datatype': None, 'handler': None,
+                      'minOccurs': None, 'maxOccurs': None, 'attribute': None}
+
+    def make_one(self, **kwargs):
+        args = self.default_kwargs.copy()
+        args.update(kwargs)
+        return self.Class(**args)
+
+
+class BaseInfoTestCase(InfoMixin, unittest.TestCase):
+
+    Class = BaseInfo
+
+    def test_constructor_error(self):
+        self.assertRaisesRegexp(SchemaError,
+                                'maxOccurs',
+                                self.make_one,
+                                maxOccurs=0)
+
+        # This case doesn't really make sense
+        self.assertRaisesRegexp(SchemaError,
+                                'minOccurs',
+                                self.make_one,
+                                maxOccurs=1,
+                                minOccurs=2)
+
+    def test_repr(self):
+        # just doesn't raise
+        repr(self.make_one())
+
+class BaseKeyInfoTestCase(InfoMixin, unittest.TestCase):
+
+    class Class(BaseKeyInfo):
+        def add_valueinfo(self, vi, key):
+            pass
+
+    def test_cant_instantiate(self):
+        self.Class = BaseKeyInfo
+        with self.assertRaises(TypeError):
+            self.make_one()
+        del self.Class
+
+    def test_finish(self):
+        info = self.make_one(minOccurs=1)
+        info.finish()
+        with self.assertRaises(SchemaError):
+            info.finish()
+
+    def test_adddefaultc(self):
+        info = self.make_one(name='foo', minOccurs=1)
+        self.assertRaisesRegexp(SchemaError,
+                                'unexpected key for default',
+                                info.adddefault,
+                                None, None, key='key')
+
+class KeyInfoTestCase(InfoMixin, unittest.TestCase):
+
+    Class = KeyInfo
+    default_kwargs = InfoMixin.default_kwargs.copy()
+    default_kwargs.pop('maxOccurs')
+
+    def test_add_with_default(self):
+        info = self.make_one(minOccurs=1, name='name')
+        info.adddefault('value', None)
+        self.assertRaisesRegexp(SchemaError,
+                                'cannot set more than one',
+                                info.adddefault,
+                                'value', None)
+
+class SectionInfoTestCase(InfoMixin, unittest.TestCase):
+
+    Class = SectionInfo
+
+    class MockSectionType(object):
+        name = None
+        @classmethod
+        def isabstract(cls):
+            return True
+
+    default_kwargs = InfoMixin.default_kwargs.copy()
+    default_kwargs.pop('datatype')
+    default_kwargs['sectiontype'] = MockSectionType
+
+    def test_constructor_error(self):
+        self.assertRaisesRegexp(SchemaError,
+                                'must use a name',
+                                self.make_one,
+                                name='name', maxOccurs=2)
+        self.assertRaisesRegexp(SchemaError,
+                                'must specify a target attribute',
+                                self.make_one,
+                                name='*', maxOccurs=2)
+
+    def test_misc(self):
+        info = self.make_one(maxOccurs=1)
+        repr(info)
+        self.assertFalse(info.isAllowedName('*'))
+        self.assertFalse(info.isAllowedName('+'))
+
+class AbstractTypeTestCase(unittest.TestCase):
+
+    def test_subtypes(self):
+
+        t = AbstractType('name')
+        self.assertFalse(t.hassubtype('foo'))
+        self.assertEqual([], list(t.getsubtypenames()))
+
+        self.name = 'foo'
+        t.addsubtype(self)
+        self.assertTrue(t.hassubtype('foo'))
+
+class SectionTypeTestCase(unittest.TestCase):
+
+    def make_one(self, name='', keytype=None, valuetype=None,
+                 datatype=None, registry={}, types=None):
+        return SectionType(name, keytype, valuetype, datatype, registry, types)
+
+    def test_getinfo_no_key(self):
+        info = self.make_one()
+        self.assertRaisesRegexp(ConfigurationError,
+                                "cannot match a key without a name",
+                                info.getinfo,
+                                None)
+
+    def test_required_types_with_name(self):
+        info = self.make_one(name='foo')
+        self.assertEqual(['foo'], info.getrequiredtypes())
+
+    def test_getsectioninfo(self):
+        class MockChild(object):
+            _issection = False
+            def issection(self):
+                return self._issection
+        child = MockChild()
+
+        info = self.make_one()
+
+        info._children.append(('foo', child))
+
+        self.assertRaisesRegexp(ConfigurationError,
+                                'already in use for key',
+                                info.getsectioninfo,
+                                None, 'foo')
+
+        self.assertRaisesRegexp(ConfigurationError,
+                                'no matching section',
+                                info.getsectioninfo,
+                                None, 'baz')
+
+class SchemaTypeTestCase(unittest.TestCase):
+
+    def test_various(self):
+        class Mock(object):
+            pass
+
+        mock = Mock()
+        schema = SchemaType(None, None, None, None, 'url', {})
+
+        mock.name = 'name'
+        schema.addtype(mock)
+        with self.assertRaises(SchemaError):
+            schema.addtype(mock)
+
+        self.assertTrue(schema.allowUnnamed())
+        self.assertFalse(schema.isAllowedName(None))
+
+        with self.assertRaises(SchemaError):
+            schema.deriveSectionType(schema, None, None, None, None)
+
+        schema.addComponent('name')
+        self.assertRaisesRegexp(SchemaError,
+                                'already have component',
+                                schema.addComponent,
+                                'name')
+
+def test_suite():
+    suite = unittest.makeSuite(UnboundTestCase)
+    suite.addTest(unittest.makeSuite(BaseInfoTestCase))
+    suite.addTest(unittest.makeSuite(BaseKeyInfoTestCase))
+    suite.addTest(unittest.makeSuite(KeyInfoTestCase))
+    suite.addTest(unittest.makeSuite(SectionInfoTestCase))
+    suite.addTest(unittest.makeSuite(AbstractTypeTestCase))
+    suite.addTest(unittest.makeSuite(SectionTypeTestCase))
+    suite.addTest(unittest.makeSuite(SchemaTypeTestCase))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='test_suite')

--- a/ZConfig/tests/test_info.py
+++ b/ZConfig/tests/test_info.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-import ZConfig
 from ZConfig import SchemaError
 from ZConfig import ConfigurationError
 

--- a/ZConfig/tests/test_loader.py
+++ b/ZConfig/tests/test_loader.py
@@ -30,7 +30,7 @@ from ZConfig.tests.support import CONFIG_BASE, TestHelper
 
 try:
     myfile = __file__
-except NameError:
+except NameError: # pragma: no cover
     myfile = sys.argv[0]
 
 myfile = os.path.abspath(myfile)
@@ -84,16 +84,15 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
         sio = StringIO("<schema>"
                        "  <import package='ZConfig.tests.test_loader'/>"
                        "</schema>")
-        try:
+        with self.assertRaises(ZConfig.SchemaResourceError) as ctx:
             ZConfig.loadSchemaFile(sio)
-        except ZConfig.SchemaResourceError as e:
-            self.assertEqual(e.filename, "component.xml")
-            self.assertEqual(e.package, "ZConfig.tests.test_loader")
-            self.assertTrue(e.path is None)
-            # make sure the str() doesn't raise an unexpected exception
-            str(e)
-        else:
-            self.fail("expected SchemaResourceError")
+
+        e = ctx.exception
+        self.assertEqual(e.filename, "component.xml")
+        self.assertEqual(e.package, "ZConfig.tests.test_loader")
+        self.assertTrue(e.path is None)
+        # make sure the str() doesn't raise an unexpected exception
+        str(e)
 
     def test_import_from_package(self):
         loader = ZConfig.loader.SchemaLoader()
@@ -127,16 +126,14 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
                        "  <import package='ZConfig.tests.library.widget'"
                        "          file='notthere.xml' />"
                        "</schema>")
-        try:
+        with self.assertRaises(ZConfig.SchemaResourceError) as ctx:
             loader.loadFile(sio)
-        except ZConfig.SchemaResourceError as e:
-            self.assertEqual(e.filename, "notthere.xml")
-            self.assertEqual(e.package, "ZConfig.tests.library.widget")
-            self.assertTrue(e.path)
-            # make sure the str() doesn't raise an unexpected exception
-            str(e)
-        else:
-            self.fail("expected SchemaResourceError")
+        e = ctx.exception
+        self.assertEqual(e.filename, "notthere.xml")
+        self.assertEqual(e.package, "ZConfig.tests.library.widget")
+        self.assertTrue(e.path)
+        # make sure the str() doesn't raise an unexpected exception
+        str(e)
 
     def test_import_from_package_with_directory_file(self):
         loader = ZConfig.loader.SchemaLoader()

--- a/ZConfig/tests/test_loader.py
+++ b/ZConfig/tests/test_loader.py
@@ -222,7 +222,7 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
 
     def test_isPath(self):
         assertTrue = self.assertTrue
-        isPath = ZConfig.loader.BaseLoader().isPath
+        isPath = ZConfig.loader.SchemaLoader().isPath
         assertTrue(isPath("abc"))
         assertTrue(isPath("abc/def"))
         assertTrue(isPath("/abc"))

--- a/ZConfig/tests/test_loader.py
+++ b/ZConfig/tests/test_loader.py
@@ -22,19 +22,10 @@ import ZConfig
 import ZConfig.loader
 import ZConfig.url
 
+from ZConfig._compat import NStringIO as StringIO
+from ZConfig._compat import urllib2
+
 from ZConfig.tests.support import CONFIG_BASE, TestHelper
-
-try:
-    import urllib2
-except ImportError:
-    # Python 3 support.
-    import urllib.request as urllib2
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    # Python 3 support.
-    from io import StringIO
 
 
 try:

--- a/ZConfig/tests/test_matcher.py
+++ b/ZConfig/tests/test_matcher.py
@@ -1,0 +1,151 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+
+from ZConfig import ConfigurationError
+from ZConfig import DataConversionError
+
+from ZConfig.matcher import SectionValue
+from ZConfig.matcher import SectionMatcher
+from ZConfig.matcher import BaseMatcher
+
+class SectionValueTestCase(unittest.TestCase):
+
+    def test_repr(self):
+        class MockMatcher(object):
+            type = None
+
+        matcher = MockMatcher()
+        matcher.type = MockMatcher()
+        matcher.type.name = 'matcher'
+
+        sv = SectionValue({}, 'name', matcher)
+        self.assertIn('name', repr(sv))
+
+        sv = SectionValue({}, None, matcher)
+        self.assertIn('at', repr(sv))
+
+        self.assertIs(matcher, sv.getSectionMatcher())
+
+    def test_str(self):
+        d = {'k': 'v'}
+        sv = SectionValue(d, None, None)
+        self.assertEqual(
+            'k                                       : v',
+            str(sv))
+
+class SectionMatcherTestCase(unittest.TestCase):
+
+    def test_constructor_error(self):
+        class Mock(object):
+            name = 'name'
+            def allowUnnamed(self):
+                return False
+        mock = Mock()
+        self.assertRaisesRegexp(ConfigurationError,
+                                "sections may not be unnamed",
+                                SectionMatcher,
+                                mock, mock, None, None)
+
+class BaseMatcherTestCase(unittest.TestCase):
+
+    def test_repr(self):
+        class Mock(dict):
+            name = 'name'
+
+        matcher = BaseMatcher(None, Mock(), None)
+        repr(matcher)
+
+    def test_duplicate_section_names(self):
+        class Mock(dict):
+            name = 'name'
+
+        matcher = BaseMatcher(None, Mock(), None)
+        matcher._sectionnames['foo'] = None
+
+        self.assertRaisesRegexp(ConfigurationError,
+                                "section names must not be re-used",
+                                matcher.addSection,
+                                None, 'foo', None)
+
+    def test_construct_errors(self):
+        class MockType(object):
+            attribute = 'attr'
+
+            _multi = True
+            _section = True
+
+            def ismulti(self):
+                return self._multi
+
+            def issection(self):
+                return self._section
+
+        type_ = []
+        matcher = BaseMatcher(None, type_, None)
+        type_.append( ('key', MockType() ) )
+
+        class MockSection(object):
+            def getSectionDefinition(self):
+                return self
+
+            def datatype(self, _s):
+                raise ValueError()
+
+        matcher._values['attr'] = [MockSection()]
+
+        with self.assertRaises(DataConversionError):
+            matcher.constuct()
+
+        type_[0][1]._multi = False
+        matcher._values['attr'] = MockSection()
+        with self.assertRaises(DataConversionError):
+            matcher.constuct()
+
+
+    def test_create_child_bad_name(self):
+
+        class MockType(list):
+            name = 'foo'
+            sectiontype = None
+
+            def getsectioninfo(self, type_name, name):
+                return self
+
+            def isabstract(self):
+                return False
+
+            def isAllowedName(self, name):
+                return False
+
+        t = MockType()
+        t.sectiontype = MockType()
+        matcher = BaseMatcher(None, t, None)
+        self.assertRaisesRegexp(ConfigurationError,
+                                'is not an allowed name',
+                                matcher.createChildMatcher,
+                                MockType(), 'ignored')
+
+
+
+def test_suite():
+    suite = unittest.makeSuite(SectionValueTestCase)
+    suite.addTest(unittest.makeSuite(SectionMatcherTestCase))
+    suite.addTest(unittest.makeSuite(BaseMatcherTestCase))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='test_suite')

--- a/ZConfig/tests/test_schema.py
+++ b/ZConfig/tests/test_schema.py
@@ -731,12 +731,10 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
         self.assertEqual(e.lineno, 3)
 
     def get_data_conversion_error(self, schema, src, url):
-        try:
+        with self.assertRaises(ZConfig.DataConversionError) as e:
             self.load_config_text(schema, src, url=url)
-        except ZConfig.DataConversionError as e:
-            return e
-        else:
-            self.fail("expected ZConfig.DataConversionError")
+
+        return e.exception
 
     def test_numeric_section_name(self):
         schema = self.load_schema_text("""\
@@ -1077,10 +1075,7 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
 
     def test_srepr(self):
         from ZConfig.schema import _srepr
-        try:
-            FOO = unicode('foo')
-        except NameError:
-            FOO = 'foo'
+        FOO = u'foo'
         self.assertEqual(_srepr('foo'), "'foo'")
         self.assertEqual(_srepr(FOO), "'foo'")
 

--- a/ZConfig/tests/test_schemaless.py
+++ b/ZConfig/tests/test_schemaless.py
@@ -18,7 +18,17 @@ Test driver for ZConfig.schemaless.
 __docformat__ = "reStructuredText"
 
 import doctest
+import unittest
 
+from ZConfig.schemaless import Section
+
+class TestSection(unittest.TestCase):
+
+    def test_init_with_data(self):
+        s = Section(data={'k': 'v'})
+        self.assertDictEqual(s, {'k': 'v'})
 
 def test_suite():
-    return doctest.DocFileSuite("schemaless.txt", package="ZConfig")
+    suite = unittest.makeSuite(TestSection)
+    suite.addTest(doctest.DocFileSuite("schemaless.txt", package="ZConfig"))
+    return suite

--- a/ZConfig/url.py
+++ b/ZConfig/url.py
@@ -35,7 +35,9 @@ def urlunsplit(parts):
     if (parts[0] == "file"
         and url.startswith("file:/")
         and not url.startswith("file:///")):
-        url = "file://" + url[5:]
+        # It may not be possible to get here anymore with
+        # modern urlparse, at least not on posix?
+        url = "file://" + url[5:] # pragma: no cover
     return url
 
 
@@ -47,5 +49,7 @@ def urldefrag(url):
 def urljoin(base, relurl):
     url = _urlparse.urljoin(base, relurl)
     if url.startswith("file:/") and not url.startswith("file:///"):
-        url = "file://" + url[5:]
+        # It may not be possible to get here anymore with
+        # modern urlparse, at least not on posix?
+        url = "file://" + url[5:] # pragma: no cover
     return url

--- a/ZConfig/url.py
+++ b/ZConfig/url.py
@@ -17,11 +17,7 @@ ZConfig and urllib2 expect file: URLs to consistently use the '//'
 hostpart seperator; the functions here enforce this constraint.
 """
 
-try:
-    import urlparse as _urlparse
-except ImportError:
-    # Python 3 support
-    import urllib.parse as _urlparse
+from ZConfig._compat import urlparse as _urlparse
 
 urlsplit = _urlparse.urlsplit
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ doc_files =
     README.txt
     doc/schema.dtd
     doc/zconfig.pdf
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ def alltests():
     suites = list(zope.testrunner.find.find_suites(options))
     return unittest.TestSuite(suites)
 
+tests_require = [
+    'zope.testrunner',
+]
+
 options = dict(
     name="ZConfig",
     version='3.2.0.dev0',
@@ -56,6 +60,8 @@ options = dict(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
@@ -63,9 +69,10 @@ options = dict(
         ],
     # Support for 'setup.py test' when setuptools is available:
     test_suite='__main__.alltests',
-    tests_require=[
-        'zope.testrunner',
-        ],
+    tests_require=tests_require,
+    extras_require={
+        'test': tests_require,
+    },
     )
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 commands =


### PR DESCRIPTION
Mostly this means new tests. Sometimes its means "no cover" markers. In a few cases it means using a shorter, more declarative way to write the code (e.g., `@total_ordering` or `ABCMeta`) or unifying python2/python 3 branches as much as possible. Sometimes we got lucky and could drop code meant for 2.6 or earlier.

There are a few genuine bugfixes in here that were revealed by getting the coverage up.

I tried to limit the use of 'no cover' as much as possible. There are a few deeply nested functions that made it difficult to avoid, though.

This replaces #12.