### PR TITLE
Give schema2html the ability to handle components.xml

### DIFF
--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -17,6 +17,7 @@ import copy
 import ZConfig
 
 from abc import abstractmethod
+from collections import OrderedDict
 from functools import total_ordering
 
 from ZConfig._compat import AbstractBaseClass
@@ -137,7 +138,7 @@ class BaseKeyInfo(AbstractBaseClass, BaseInfo):
         assert self.name == "+"
         if self._rawdefaults is None:
             self._rawdefaults = self._default
-        self._default = {}
+        self._default = OrderedDict()
 
 
 class KeyInfo(BaseKeyInfo):
@@ -148,7 +149,7 @@ class KeyInfo(BaseKeyInfo):
         BaseKeyInfo.__init__(self, name, datatype, minOccurs, 1,
                              handler, attribute)
         if self.name == "+":
-            self._default = {}
+            self._default = OrderedDict()
 
     def add_valueinfo(self, vi, key):
         if self.name == "+":
@@ -184,7 +185,7 @@ class MultiKeyInfo(BaseKeyInfo):
         BaseKeyInfo.__init__(self, name, datatype, minOccurs, maxOccurs,
                              handler, attribute)
         if self.name == "+":
-            self._default = {}
+            self._default = OrderedDict()
         else:
             self._default = []
 
@@ -275,12 +276,12 @@ class AbstractType(object):
     __slots__ = '_subtypes', 'name', 'description'
 
     def __init__(self, name):
-        self._subtypes = {}
+        self._subtypes = OrderedDict()
         self.name = name
         self.description = None
 
     def __iter__(self):
-        return iter(sorted(self._subtypes.items()))
+        return iter(self._subtypes.items())
 
     def addsubtype(self, type):
         self._subtypes[type.name] = type
@@ -319,8 +320,8 @@ class SectionType(object):
         self.example = None
         self.registry = registry
         self._children = []    # [(key, info), ...]
-        self._attrmap = {}     # {attribute: info, ...}
-        self._keymap = {}      # {key: info, ...}
+        self._attrmap = OrderedDict()     # {attribute: info, ...}
+        self._keymap = OrderedDict()      # {key: info, ...}
         self._types = types
 
     def gettype(self, name):
@@ -378,7 +379,7 @@ class SectionType(object):
             raise ZConfig.ConfigurationError("no key matching " + repr(key))
 
     def getrequiredtypes(self):
-        d = {}
+        d = OrderedDict()
         if self.name:
             d[self.name] = 1
         stack = [self]
@@ -443,7 +444,7 @@ class SchemaType(SectionType):
                  registry):
         SectionType.__init__(self, None, keytype, valuetype, datatype,
                              registry, {})
-        self._components = {}
+        self._components = OrderedDict()
         self.handler = handler
         self.url = url
 

--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -269,13 +269,18 @@ class SectionInfo(BaseInfo):
 
 
 class AbstractType(object):
-
+    # This isn't actually "abstract" in the Python ABC sense,
+    # it's only abstract from the schema sense. This class is
+    # instantiated, and not expected to be subclassed.
     __slots__ = '_subtypes', 'name', 'description'
 
     def __init__(self, name):
         self._subtypes = {}
         self.name = name
         self.description = None
+
+    def __iter__(self):
+        return iter(sorted(self._subtypes.items()))
 
     def addsubtype(self, type):
         self._subtypes[type.name] = type
@@ -333,6 +338,12 @@ class SectionType(object):
 
     def __getitem__(self, index):
         return self._children[index]
+
+    def __iter__(self):
+        return iter(self._children)
+
+    def itertypes(self):
+        return iter(sorted(self._types.items()))
 
     def _add_child(self, key, info):
         # check naming constraints

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -49,7 +49,7 @@ def run_transform(*args):
         with stdout_replaced(buf):
             schema2html.main(args)
         return buf
-    return schema2html.main(args)
+    return schema2html.main(args) # pragma: no cover
 
 
 
@@ -79,6 +79,9 @@ class TestSchema2HTML(unittest.TestCase):
             res = run_transform(input_file(name))
             self.assertIn('</html>', res.getvalue())
 
+    def test_cover_logging_components(self):
+        res = run_transform('--package', 'ZConfig.components.logger')
+        self.assertIn('eventlog', res.getvalue())
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
Fixes #23 

Eyeballed for logging here, and RelStorage.

Though, for something like RelStorage where it imports ZODB, we wind up documenting more than we want to. I'm not sure what to do about that. An eventual sphinx extension might support a blacklist?

And also the organization still leaves something to be desired. But, baby steps.