### PR TITLE
Add a docutils directive and connect schema2html to sphinx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Change History for ZConfig
 - Scripts ``zconfig`` (for schema validation) and
   ``zconfig_schema2html`` are ported to Python 3.
 
+- A new ``ZConfig.sphinx`` Sphinx extension facilitates automatically
+  documenting ZConfig components using their description and examples
+  in Sphinx documentation.
+
 3.1.0 (2015-10-17)
 ------------------
 

--- a/ZConfig/_compat.py
+++ b/ZConfig/_compat.py
@@ -19,9 +19,11 @@ PY3 = sys.version_info[0] >= 3
 # Native string object IO
 if str is not bytes:
     from io import StringIO as NStringIO
+    string_types = str
 else:
     # Python 2
     from io import BytesIO as NStringIO
+    string_types = str, unicode
 
 NStringIO = NStringIO
 

--- a/ZConfig/_schema_utils.py
+++ b/ZConfig/_schema_utils.py
@@ -35,6 +35,7 @@ from ZConfig.datatypes import null_conversion
 from ZConfig.info import SectionType
 from ZConfig.info import SectionInfo
 from ZConfig.info import ValueInfo
+from ZConfig.info import MultiKeyInfo
 from ZConfig.info import AbstractType
 
 
@@ -290,7 +291,10 @@ class AbstractSchemaPrinter(AbstractBaseClass):
         if isinstance(default, ValueInfo):
             default = default.value
 
-        self.fmt.describing_name(info.name, info.description, info.datatype,
+        name = info.name
+        if isinstance(info, MultiKeyInfo):
+            name = name + " (*)"
+        self.fmt.describing_name(name, info.description, info.datatype,
                                  default=default, metadefault=info.metadefault)
 
     del TypeVisitor

--- a/ZConfig/_schema_utils.py
+++ b/ZConfig/_schema_utils.py
@@ -249,7 +249,7 @@ def load_schema(schema, package, package_file):
         schema_reader = argparse.FileType('r')(schema)
     else:
         schema_template = "<schema><import package='%s' file='%s' /></schema>" % (
-            schema, package_file)
+            schema, package_file or 'component.xml')
         from ZConfig._compat import TextIO
         schema_reader = TextIO(schema_template)
 

--- a/ZConfig/_schema_utils.py
+++ b/ZConfig/_schema_utils.py
@@ -1,0 +1,257 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Corporation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import print_function
+
+from abc import abstractmethod
+import argparse
+from contextlib import contextmanager
+import itertools
+import sys
+import cgi
+
+import ZConfig.loader
+
+from ZConfig._compat import AbstractBaseClass
+
+from ZConfig.datatypes import null_conversion
+from ZConfig.info import SectionType
+from ZConfig.info import SectionInfo
+from ZConfig.info import ValueInfo
+from ZConfig.info import AbstractType
+
+
+class _VisitorBuilder(object):
+
+    def __init__(self):
+        self.visitors = []
+
+    def __call__(self, Type):
+        def dec(func):
+            self.visitors.append((Type, func))
+            return func
+        return dec
+
+MARKER = object()
+
+class AbstractSchemaFormatter(AbstractBaseClass):
+
+    def __init__(self, schema, stream=None):
+        self.stream = stream or sys.stdout
+        self._dt = schema.registry.find_name
+
+    def write(self, *args):
+        print(*args, file=self.stream)
+
+    @abstractmethod
+    def esc(self, x):
+        "Escape blocks of text if needed"
+
+    @abstractmethod
+    def item_list(self):
+        "Context manager for listing description items"
+
+    def _describing(self, description, after):
+        if description is not MARKER:
+            with self.described_as():
+                self.description(description)
+                if after:
+                    after()
+
+    @abstractmethod
+    def describing(self, description=MARKER, after=None):
+        "description term, optional body"
+
+    def describing_name(self, concrete_name,
+                        description=MARKER, datatype=None,
+                        **kwargs):
+        with self.describing(description):
+            self.concrete_name(concrete_name)
+            self.datatype(datatype)
+
+            for k, v in sorted(kwargs.items()):
+                if v:
+                    self.write(self.esc("(%s: %s)" % (k, v)))
+
+    def description(self, description):
+        if description:
+            self.write(self.esc(description))
+
+    @abstractmethod
+    def described_as(self):
+        "Description body context manager"
+
+    @abstractmethod
+    def abstract_name(self, name):
+        "Abstract name"
+
+    @abstractmethod
+    def concrete_name(self, *name):
+        "Concrete name"
+
+    @abstractmethod
+    def concrete_section_name(self, *name):
+        "Name of a section a user can type in a config"
+
+    def datatype(self, datatype):
+        self.write("(%s)" % self._dt(datatype))
+
+    @abstractmethod
+    def body(self):
+        "Context manager for the whole document"
+
+
+class AbstractSchemaPrinter(AbstractBaseClass):
+
+
+    def __init__(self, schema, stream=None):
+        self.schema = schema
+        stream = stream or sys.stdout
+        self._explained = set()
+        self._seen_typenames = set()
+        self.fmt = self._schema_formatter(schema, stream)
+
+    @abstractmethod
+    def _schema_formatter(self, schema, stream):
+        "Return a formatter"
+
+    def _explain(self, st):
+        if st.name in self._explained: # pragma: no cover
+            return
+
+        self._explained.add(st.name)
+
+        self.fmt.description(st.description)
+        for sub in st.getsubtypenames():
+            with self.fmt.item_list():
+                self.visit(None, st.getsubtype(sub))
+
+    def _iter_schema_items(self):
+        def everything():
+            return itertools.chain(self.schema.itertypes(),
+                                   self.schema)
+        # The abstract types tend to be the most important. Since
+        # we only document a concrete type the first time we find it,
+        # and we can find extensions of abstract types beneath
+        # the abstract type which is itself buried under a concrete section,
+        # all the different permutations would be only documented once under
+        # that section. By exposing these first, they get documented at the top-level,
+        # and each concrete section that uses the abstract type gets a reference
+        # to it.
+
+        def abstract_sections(base):
+            for name, info in base:
+                if isinstance(info, SectionInfo):
+                    if info.sectiontype.isabstract():
+                        yield name, info
+
+                    # XXX: This isn't catching everything. Witness the
+                    # relstorage component.
+                elif isinstance(info, SectionType):
+                    for x in abstract_sections(info):
+                        yield x
+        return itertools.chain(abstract_sections(everything()), everything())
+
+    def printSchema(self):
+        # side-effect of building may be printing
+        self.buildSchema()
+
+    def buildSchema(self):
+        seen = set() # prevent duplicates at the top-level
+        # as we find multiple abstract types
+        with self.fmt.body():
+            with self.fmt.item_list():
+                for name, info in self._iter_schema_items():
+                    if info in seen:
+                        continue
+                    seen.add(info)
+                    self.visit(name, info)
+
+    TypeVisitor = _VisitorBuilder()
+    visitors = TypeVisitor.visitors
+
+    def visit(self, name, info):
+        for t, f in self.visitors:
+            if isinstance(info, t):
+                f(self, name, info)
+                break
+        else:
+            self._visit_default(name, info)
+
+    @TypeVisitor(SectionType)
+    def _visit_SectionType(self, name, info):
+        if info.name in self._seen_typenames:
+            return
+        self._seen_typenames.add(info.name)
+        with self.fmt.describing():
+            if info.datatype is not null_conversion:
+                self.fmt.concrete_section_name(info.name)
+            else:
+                self.fmt.abstract_name(info.name)
+            self.fmt.datatype(info.datatype)
+
+        with self.fmt.described_as():
+            self.fmt.description(info.description)
+
+            with self.fmt.item_list():
+                for sub in info:
+                    self.visit(*sub) # pragma: no cover
+
+
+    @TypeVisitor(SectionInfo)
+    def _visit_SectionInfo(self, name, info):
+        st = info.sectiontype
+        if st.isabstract():
+            with self.fmt.describing(info.description, lambda: self._explain(st)):
+                self.fmt.abstract_name(st.name)
+                self.fmt.concrete_name(info.name)
+
+        else:
+            with self.fmt.describing():
+                self.fmt.concrete_section_name(info.attribute, info.name)
+                self.fmt.datatype(info.datatype)
+
+            with self.fmt.described_as():
+                with self.fmt.item_list():
+                    for sub in info.sectiontype:
+                        self.visit(*sub)
+
+
+    @TypeVisitor(AbstractType)
+    def _visit_AbstractType(self, name, info):
+        with self.fmt.describing(info.description, lambda: self._explain(info)):
+            self.fmt.abstract_name(info.name)
+
+    def _visit_default(self, name, info):
+        # KeyInfo or MultiKeyInfo
+        default = info.getdefault()
+        if isinstance(default, ValueInfo):
+            default = default.value
+
+        self.fmt.describing_name(info.name, info.description, info.datatype,
+                                 default=default, metadefault=info.metadefault)
+
+    del TypeVisitor
+
+
+def load_schema(schema, package, package_file):
+    if not package:
+        schema_reader = argparse.FileType('r')(schema)
+    else:
+        schema_template = "<schema><import package='%s' file='%s' /></schema>" % (
+            schema, package_file)
+        from ZConfig._compat import TextIO
+        schema_reader = TextIO(schema_template)
+
+    schema = ZConfig.loader.loadSchemaFile(schema_reader)
+    return schema

--- a/ZConfig/_schema_utils.py
+++ b/ZConfig/_schema_utils.py
@@ -15,10 +15,9 @@ from __future__ import print_function
 
 from abc import abstractmethod
 import argparse
-from contextlib import contextmanager
 import itertools
 import sys
-import cgi
+
 
 import ZConfig.loader
 
@@ -114,12 +113,22 @@ class AbstractSchemaFormatter(AbstractBaseClass):
 class AbstractSchemaPrinter(AbstractBaseClass):
 
 
-    def __init__(self, schema, stream=None):
+    def __init__(self, schema, stream=None, allowed_names=()):
         self.schema = schema
         stream = stream or sys.stdout
         self._explained = set()
         self._seen_typenames = set()
         self.fmt = self._schema_formatter(schema, stream)
+
+        if allowed_names:
+            iter_all = self._iter_schema_items
+            allowed_names = {x.lower() for x in allowed_names}
+            def filtered():
+                for name, info in iter_all():
+                    if name and name.lower() in allowed_names:
+                        yield name, info
+
+            self._iter_schema_items = filtered
 
     @abstractmethod
     def _schema_formatter(self, schema, stream):

--- a/ZConfig/components/logger/base-logger.xml
+++ b/ZConfig/components/logger/base-logger.xml
@@ -8,6 +8,16 @@
       ZConfig.components.logger.  This exists entirely to provide
       shared key definitions and documentation.
     </description>
+    <example><![CDATA[
+          <logger>
+              level INFO
+              <logfile>
+                  path STDOUT
+                  format %(levelname)s %(name)s %(message)s
+              </logfile>
+          </logger>
+		  ]]>
+    </example>
 
     <key name="level"
          datatype="ZConfig.components.logger.datatypes.logging_level"

--- a/ZConfig/components/logger/base-logger.xml
+++ b/ZConfig/components/logger/base-logger.xml
@@ -16,7 +16,7 @@
         Verbosity setting for the logger.  Values must be a name of
         a level, or an integer in the range [0..50].  The names of the
         levels, in order of increasing verbosity (names on the same
-        line are equivalent):
+        line are equivalent)::
 
             critical, fatal
             error

--- a/ZConfig/components/logger/handlers.xml
+++ b/ZConfig/components/logger/handlers.xml
@@ -82,6 +82,17 @@
                datatype=".SMTPHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
+    <example><![CDATA[
+      <email-notifier>
+        to sysadmin@example.com
+        to john@example.com
+        from zlog-user@example.com
+        level fatal
+        smtp-username john
+        smtp-password johnpw
+      </email-notifier>
+    ]]>
+    </example>
     <key name="from" required="yes" attribute="fromaddr"/>
     <multikey name="to" required="yes" attribute="toaddrs"/>
     <key name="subject" default="Message from Zope"/>

--- a/ZConfig/components/logger/handlers.xml
+++ b/ZConfig/components/logger/handlers.xml
@@ -29,6 +29,13 @@
                datatype=".FileHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
+	<example><![CDATA[
+        <logfile>
+            path STDOUT
+            format %(name)s %(message)s
+        </logfile>
+    ]]>
+    </example>
     <key name="path" required="yes"/>
     <key name="old-files" required="no" default="0" datatype="integer"/>
     <key name="max-size" required="no" default="0" datatype="byte-size"/>

--- a/ZConfig/datatypes.py
+++ b/ZConfig/datatypes.py
@@ -452,6 +452,17 @@ class Registry(object):
         self._other = {}
         self._basic_key = None
 
+    def find_name(self, conversion):
+        """Return the best name for *conversion*, which must have been returned
+        from *get* on this object."""
+        for dct in self._other, self._stock:
+            for k, v in dct.items():
+                if v is conversion:
+                    return k
+
+        # If they followed the rules, we shouldn't get here.
+        return str(conversion) # pragma: no cover
+
     def get(self, name):
         """Return the type conversion routine for *name*.
 

--- a/ZConfig/schema2html.py
+++ b/ZConfig/schema2html.py
@@ -15,41 +15,16 @@ from __future__ import print_function
 
 import argparse
 from contextlib import contextmanager
-import itertools
-import sys
 import cgi
+import sys
 
-import ZConfig.loader
+from ZConfig._schema_utils import AbstractSchemaPrinter
+from ZConfig._schema_utils import AbstractSchemaFormatter
+from ZConfig._schema_utils import MARKER
+from ZConfig._schema_utils import load_schema
+from ZConfig.sphinx import RstSchemaPrinter
 
-from ZConfig.datatypes import null_conversion
-from ZConfig.info import SectionType
-from ZConfig.info import SectionInfo
-from ZConfig.info import ValueInfo
-from ZConfig.info import AbstractType
-
-from ZConfig._compat import string_types
-
-class _VisitorBuilder(object):
-
-    def __init__(self):
-        self.visitors = []
-
-    def __call__(self, Type):
-        def dec(func):
-            self.visitors.append((Type, func))
-            return func
-        return dec
-
-_MARKER = object()
-
-class SchemaFormatter(object):
-
-    def __init__(self, schema, stream=None):
-        self.stream = stream or sys.stdout
-        self._dt = schema.registry.find_name
-
-    def write(self, *args):
-        print(*args, file=self.stream)
+class HtmlSchemaFormatter(AbstractSchemaFormatter):
 
     def esc(self, x):
         return cgi.escape(str(x))
@@ -63,33 +38,11 @@ class SchemaFormatter(object):
     def item_list(self):
         return self._simple_tag("dl")
 
-    def _describing(self, description, after):
-        if description is not _MARKER:
-            with self.described_as():
-                self.description(description)
-                if after:
-                    after()
-
     @contextmanager
-    def describing(self, description=_MARKER, after=None):
+    def describing(self, description=MARKER, after=None):
         with self._simple_tag("dt"):
             yield
         self._describing(description, after)
-
-    def describing_name(self, concrete_name,
-                        description=_MARKER, datatype=None,
-                        **kwargs):
-        with self.describing(description):
-            self.concrete_name(concrete_name)
-            self.datatype(datatype)
-
-            for k, v in sorted(kwargs.items()):
-                if v:
-                    self.write(self.esc("(%s: %s)" % (k, v)))
-
-    def description(self, description):
-        if description:
-            self.write(self.esc(description))
 
     def described_as(self):
         return self._simple_tag("dd")
@@ -118,299 +71,9 @@ class SchemaFormatter(object):
         yield
         self.write('</body></html>')
 
+class HtmlSchemaPrinter(AbstractSchemaPrinter):
 
-class SchemaPrinter(object):
-
-    SchemaFormatter = SchemaFormatter
-
-    def __init__(self, schema, stream=None):
-        self.schema = schema
-        stream = stream or sys.stdout
-        self._explained = set()
-        self._seen_typenames = set()
-        self.fmt = self.SchemaFormatter(schema, stream)
-
-
-    def _explain(self, st):
-        if st.name in self._explained: # pragma: no cover
-            return
-
-        self._explained.add(st.name)
-
-        self.fmt.description(st.description)
-        for sub in st.getsubtypenames():
-            with self.fmt.item_list():
-                self.visit(None, st.getsubtype(sub))
-
-    def _iter_schema_items(self):
-        def everything():
-            return itertools.chain(self.schema.itertypes(),
-                                   self.schema)
-        # The abstract types tend to be the most important. Since
-        # we only document a concrete type the first time we find it,
-        # and we can find extensions of abstract types beneath
-        # the abstract type which is itself buried under a concrete section,
-        # all the different permutations would be only documented once under
-        # that section. By exposing these first, they get documented at the top-level,
-        # and each concrete section that uses the abstract type gets a reference
-        # to it.
-
-        def abstract_sections(base):
-            for name, info in base:
-                if isinstance(info, SectionInfo):
-                    if info.sectiontype.isabstract():
-                        yield name, info
-
-                    # XXX: This isn't catching everything. Witness the
-                    # relstorage component.
-                elif isinstance(info, SectionType):
-                    for x in abstract_sections(info):
-                        yield x
-        return itertools.chain(abstract_sections(everything()), everything())
-
-    def printSchema(self):
-        # side-effect of building may be printing
-        self.buildSchema()
-
-    def buildSchema(self):
-        seen = set() # prevent duplicates at the top-level
-        # as we find multiple abstract types
-        with self.fmt.body():
-            with self.fmt.item_list():
-                for name, info in self._iter_schema_items():
-                    if info in seen:
-                        continue
-                    seen.add(info)
-                    self.visit(name, info)
-
-    TypeVisitor = _VisitorBuilder()
-    visitors = TypeVisitor.visitors
-
-    def visit(self, name, info):
-        for t, f in self.visitors:
-            if isinstance(info, t):
-                f(self, name, info)
-                break
-        else:
-            self._visit_default(name, info)
-
-    @TypeVisitor(SectionType)
-    def _visit_SectionType(self, name, info):
-        if info.name in self._seen_typenames:
-            return
-        self._seen_typenames.add(info.name)
-        with self.fmt.describing():
-            if info.datatype is not null_conversion:
-                self.fmt.concrete_section_name(info.name)
-            else:
-                self.fmt.abstract_name(info.name)
-            self.fmt.datatype(info.datatype)
-
-        with self.fmt.described_as():
-            self.fmt.description(info.description)
-
-            with self.fmt.item_list():
-                for sub in info:
-                    self.visit(*sub) # pragma: no cover
-
-
-    @TypeVisitor(SectionInfo)
-    def _visit_SectionInfo(self, name, info):
-        st = info.sectiontype
-        if st.isabstract():
-            with self.fmt.describing(info.description, lambda: self._explain(st)):
-                self.fmt.abstract_name(st.name)
-                self.fmt.concrete_name(info.name)
-
-        else:
-            with self.fmt.describing():
-                self.fmt.concrete_section_name(info.attribute, info.name)
-                self.fmt.datatype(info.datatype)
-
-            with self.fmt.described_as():
-                with self.fmt.item_list():
-                    for sub in info.sectiontype:
-                        self.visit(*sub)
-
-
-    @TypeVisitor(AbstractType)
-    def _visit_AbstractType(self, name, info):
-        with self.fmt.describing(info.description, lambda: self._explain(info)):
-            self.fmt.abstract_name(info.name)
-
-    def _visit_default(self, name, info):
-        # KeyInfo or MultiKeyInfo
-        default = info.getdefault()
-        if isinstance(default, ValueInfo):
-            default = default.value
-
-        self.fmt.describing_name(info.name, info.description, info.datatype,
-                                 default=default, metadefault=info.metadefault)
-
-    del TypeVisitor
-
-try:
-    from docutils import nodes
-    import docutils.utils
-    import docutils.frontend
-    import docutils.parsers.rst
-    from docutils.parsers.rst import Directive
-except ImportError: # pragma: no cover
-    RstSchemaPrinter = None
-    RstSchemaFormatter = None
-else:
-    class RstSchemaFormatter(SchemaFormatter):
-
-        settings = None
-
-        def __init__(self, schema, stream=None):
-            super(RstSchemaFormatter, self).__init__(schema, stream)
-            self.document = None
-            self._current_node = None
-            self._nodes = []
-
-        def esc(self, text):
-            return text
-
-        def _parsed(self, text):
-            document = docutils.utils.new_document(
-                "Schema",
-                settings=self.settings or docutils.frontend.OptionParser(
-                    components=(docutils.parsers.rst.Parser,)
-                    ).get_default_values())
-            parser = docutils.parsers.rst.Parser()
-            parser.parse(text, document)
-            return document.children
-
-        def write(self, *texts):
-            for text in texts:
-                if isinstance(text, string_types):
-                    self._current_node += nodes.Text(' ' + text + ' ', text)
-                else:
-                    # Already parsed
-                    self._current_node += text
-
-        def description(self, text):
-            if not text:
-                return
-
-            # Aggressively dedent the text to avoid producing unwanted
-            # definition lists.
-            # XXX: This is probably *too* aggressive.
-            texts = []
-            parts = text.split('\n')
-            for p in parts:
-                p = p.strip()
-                if not p:
-                    texts.append('\n')
-                else:
-                    texts.append(p)
-            text = '\n'.join(texts)
-            self.write(self._parsed(text))
-
-
-        @contextmanager
-        def item_list(self):
-            old_node = self._current_node
-            self._current_node = nodes.definition_list()
-            old_node += self._current_node
-            yield
-            self._current_node = old_node
-
-
-        @contextmanager
-        def describing(self, description=_MARKER, after=None):
-            dl = self._current_node
-            assert isinstance(dl, nodes.definition_list), dl
-            item = nodes.definition_list_item()
-            dl += item
-            term = nodes.term()
-            item += term
-            self._current_node = term
-
-            yield
-
-            # We must now have either a description (so we call
-            # described_as) or they must call described_as
-            # des
-            self._current_node = item
-
-            self._describing(description, after)
-
-
-        @contextmanager
-        def described_as(self):
-            item = self._current_node
-            assert isinstance(item, nodes.definition_list_item), item
-
-            definition = nodes.definition()
-            para = nodes.paragraph()
-            definition += para
-            item += definition
-            self._current_node = para
-
-            yield
-
-            # When this is done, we're back to the list
-            self._current_node = item.parent
-
-        def abstract_name(self, name):
-            self._current_node += nodes.emphasis(text=name, rawsource=name)
-
-        def concrete_name(self, name):
-            self._current_node += nodes.strong(text=name, rawsource=name)
-
-        def concrete_section_name(self, *name):
-            name = ' '.join(name)
-            return self.concrete_name("<" + name + ">")
-
-        @contextmanager
-        def body(self):
-            self.document = self._current_node = docutils.utils.new_document(
-                "Schema",
-                settings=self.settings or docutils.frontend.OptionParser(
-                    components=(docutils.parsers.rst.Parser,)
-                    ).get_default_values())
-            yield
-
-    class RstSchemaPrinter(SchemaPrinter):
-        SchemaFormatter = RstSchemaFormatter
-
-        def printSchema(self):
-            super(RstSchemaPrinter, self).printSchema()
-            print(self.fmt.document.pformat(), file=self.fmt.stream)
-
-
-    class SchemaToRstDirective(Directive):
-        required_arguments = 1
-
-        def run(self): # pragma: no cover
-            schema = _load_schema(self.arguments[0], True, 'component.xml')
-
-            printer = RstSchemaPrinter(schema)
-            try:
-                printer.fmt.settings = self.state.document.settings
-            except AttributeError:
-                pass
-            printer.buildSchema()
-
-            return printer.fmt.document.children
-
-    def setup(app): # pragma: no cover
-        "Sphinx extension entry point to add the zconfig directive."
-        app.add_directive("zconfig", SchemaToRstDirective)
-
-def _load_schema(schema, package, package_file):
-    if not package:
-        schema_reader = argparse.FileType('r')(schema)
-    else:
-        schema_template = "<schema><import package='%s' file='%s' /></schema>" % (
-            schema, package_file)
-        from ZConfig._compat import TextIO
-        schema_reader = TextIO(schema_template)
-
-    schema = ZConfig.loader.loadSchemaFile(schema_reader)
-    return schema
+    _schema_formatter = HtmlSchemaFormatter
 
 def main(argv=None):
     argv = argv or sys.argv[1:]
@@ -440,7 +103,7 @@ def main(argv=None):
         default="component.xml",
         help="When PACKAGE is given, this can specify the file inside it to load.")
 
-    if RstSchemaFormatter:
+    if RstSchemaPrinter:
         argparser.add_argument(
             "--format",
             action="store",
@@ -453,9 +116,9 @@ def main(argv=None):
 
     out = args.out or sys.stdout
 
-    schema = _load_schema(args.schema, args.package, args.package_file)
+    schema = load_schema(args.schema, args.package, args.package_file)
 
-    printer_factory = SchemaPrinter
+    printer_factory = HtmlSchemaPrinter
     if hasattr(args, 'format') and args.format == 'xml':
         printer_factory = RstSchemaPrinter
 
@@ -464,3 +127,6 @@ def main(argv=None):
 
 
     return 0
+
+if __name__ == '__main__':
+    main()

--- a/ZConfig/schema2html.py
+++ b/ZConfig/schema2html.py
@@ -61,6 +61,16 @@ class HtmlSchemaFormatter(AbstractSchemaFormatter):
     def datatype(self, datatype):
         self.write("(%s)" % self._dt(datatype))
 
+    def example(self, text):
+        if not text:
+            return
+
+        with self._simple_tag("p"):
+            with self._simple_tag("i"):
+                self.write("Example:")
+            with self._simple_tag("pre"):
+                self.write(self.esc(self._dedent(text)))
+
     @contextmanager
     def body(self):
         self.write('''<html><body>

--- a/ZConfig/schema2html.py
+++ b/ZConfig/schema2html.py
@@ -103,6 +103,12 @@ def main(argv=None):
         default="component.xml",
         help="When PACKAGE is given, this can specify the file inside it to load.")
 
+    argparser.add_argument(
+        "--members",
+        action="store",
+        nargs="*",
+        help="Only output sections and types in this list (and reachable from it)")
+
     if RstSchemaPrinter:
         argparser.add_argument(
             "--format",
@@ -123,7 +129,7 @@ def main(argv=None):
         printer_factory = RstSchemaPrinter
 
 
-    printer_factory(schema, out).printSchema()
+    printer_factory(schema, out, allowed_names=args.members).printSchema()
 
 
     return 0

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -159,9 +159,13 @@ else:
 
     class SchemaToRstDirective(Directive):
         required_arguments = 1
-
+        optional_arguments = 1
+        option_spec = {
+            'file': str,
+        }
         def run(self):
-            schema = load_schema(self.arguments[0], True, 'component.xml')
+            schema = load_schema(self.arguments[0],
+                                 True, self.options.get('file'))
 
             printer = RstSchemaPrinter(schema)
             printer.fmt.settings = self.state.document.settings

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -49,9 +49,9 @@ else:
         def esc(self, text):
             return text
 
-        def _parsed(self, text):
+        def _parsed(self, text, name='Schema'):
             document = docutils.utils.new_document(
-                "Schema",
+                name,
                 settings=self.settings)
 
 
@@ -71,16 +71,15 @@ else:
             if not text:
                 return
 
-            # dedent the text to avoid producing unwanted
-            # definition lists. The XML parser strips leading whitespace from
-            # the first line, but preserves it for subsequent lines, so for dedent
-            # to work we have to ignore that first line.
-            texts = text.split("\n")
-            if len(texts) > 1:
-                trail = textwrap.dedent('\n'.join(texts[1:]))
-                text = texts[0] + '\n' + trail
-            self.write(self._parsed(text))
+            self.write(self._parsed(self._dedent(text), "description"))
 
+        def example(self, text):
+            if not text:
+                return
+
+            dedented = self._dedent(text)
+            example = "Example::\n\n\t" + '\n\t'.join(dedented.split('\n'))
+            self.write(self._parsed(example, "example"))
 
         @contextmanager
         def item_list(self):

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -1,0 +1,177 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Corporation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from __future__ import print_function, absolute_import
+
+
+from contextlib import contextmanager
+
+
+try:
+    from docutils import nodes
+    import docutils.utils
+    import docutils.frontend
+    import docutils.parsers.rst
+    from docutils.parsers.rst import Directive
+except ImportError: # pragma: no cover
+    RstSchemaPrinter = None
+    RstSchemaFormatter = None
+else:
+
+    from ZConfig._compat import string_types
+    from ZConfig._schema_utils import load_schema
+    from ZConfig._schema_utils import AbstractSchemaFormatter
+    from ZConfig._schema_utils import AbstractSchemaPrinter
+    from ZConfig._schema_utils import MARKER
+
+    class RstSchemaFormatter(AbstractSchemaFormatter):
+
+        settings = None
+
+        def __init__(self, schema, stream=None):
+            super(RstSchemaFormatter, self).__init__(schema, stream)
+            self.document = None
+            self._current_node = None
+            self._nodes = []
+
+        def esc(self, text):
+            return text
+
+        def _parsed(self, text):
+            document = docutils.utils.new_document(
+                "Schema",
+                settings=self.settings or docutils.frontend.OptionParser(
+                    components=(docutils.parsers.rst.Parser,)
+                    ).get_default_values())
+            parser = docutils.parsers.rst.Parser()
+            parser.parse(text, document)
+            return document.children
+
+        def write(self, *texts):
+            for text in texts:
+                if isinstance(text, string_types):
+                    self._current_node += nodes.Text(' ' + text + ' ', text)
+                else:
+                    # Already parsed
+                    self._current_node += text
+
+        def description(self, text):
+            if not text:
+                return
+
+            # Aggressively dedent the text to avoid producing unwanted
+            # definition lists.
+            # XXX: This is probably *too* aggressive.
+            texts = []
+            parts = text.split('\n')
+            for p in parts:
+                p = p.strip()
+                if not p:
+                    texts.append('\n')
+                else:
+                    texts.append(p)
+            text = '\n'.join(texts)
+            self.write(self._parsed(text))
+
+
+        @contextmanager
+        def item_list(self):
+            old_node = self._current_node
+            self._current_node = nodes.definition_list()
+            old_node += self._current_node
+            yield
+            self._current_node = old_node
+
+
+        @contextmanager
+        def describing(self, description=MARKER, after=None):
+            dl = self._current_node
+            assert isinstance(dl, nodes.definition_list), dl
+            item = nodes.definition_list_item()
+            dl += item
+            term = nodes.term()
+            item += term
+            self._current_node = term
+
+            yield
+
+            # We must now have either a description (so we call
+            # described_as) or they must call described_as
+            # des
+            self._current_node = item
+
+            self._describing(description, after)
+
+
+        @contextmanager
+        def described_as(self):
+            item = self._current_node
+            assert isinstance(item, nodes.definition_list_item), item
+
+            definition = nodes.definition()
+            para = nodes.paragraph()
+            definition += para
+            item += definition
+            self._current_node = para
+
+            yield
+
+            # When this is done, we're back to the list
+            self._current_node = item.parent
+
+        def abstract_name(self, name):
+            self._current_node += nodes.emphasis(text=name, rawsource=name)
+
+        def concrete_name(self, *name):
+            name = ' '.join(name)
+            self._current_node += nodes.strong(text=name, rawsource=name)
+
+        def concrete_section_name(self, *name):
+            name = ' '.join(name)
+            return self.concrete_name("<" + name + ">")
+
+        @contextmanager
+        def body(self):
+            self.document = self._current_node = docutils.utils.new_document(
+                "Schema",
+                settings=self.settings or docutils.frontend.OptionParser(
+                    components=(docutils.parsers.rst.Parser,)
+                    ).get_default_values())
+            yield
+
+    class RstSchemaPrinter(AbstractSchemaPrinter):
+        _schema_formatter = RstSchemaFormatter
+
+        def printSchema(self):
+            super(RstSchemaPrinter, self).printSchema()
+            print(self.fmt.document.pformat(), file=self.fmt.stream)
+
+
+    class SchemaToRstDirective(Directive):
+        required_arguments = 1
+
+        def run(self): # pragma: no cover
+            schema = load_schema(self.arguments[0], True, 'component.xml')
+
+            printer = RstSchemaPrinter(schema)
+            try:
+                printer.fmt.settings = self.state.document.settings
+            except AttributeError:
+                pass
+            printer.buildSchema()
+
+            return printer.fmt.document.children
+
+    def setup(app): # pragma: no cover
+        "Sphinx extension entry point to add the zconfig directive."
+        app.add_directive("zconfig", SchemaToRstDirective)

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -15,7 +15,7 @@ from __future__ import print_function, absolute_import
 
 
 from contextlib import contextmanager
-
+import textwrap
 
 try:
     from docutils import nodes
@@ -71,18 +71,14 @@ else:
             if not text:
                 return
 
-            # Aggressively dedent the text to avoid producing unwanted
-            # definition lists.
-            # XXX: This is probably *too* aggressive.
-            texts = []
-            parts = text.split('\n')
-            for p in parts:
-                p = p.strip()
-                if not p:
-                    texts.append('\n')
-                else:
-                    texts.append(p)
-            text = '\n'.join(texts)
+            # dedent the text to avoid producing unwanted
+            # definition lists. The XML parser strips leading whitespace from
+            # the first line, but preserves it for subsequent lines, so for dedent
+            # to work we have to ignore that first line.
+            texts = text.split("\n")
+            if len(texts) > 1:
+                trail = textwrap.dedent('\n'.join(texts[1:]))
+                text = texts[0] + '\n' + trail
             self.write(self._parsed(text))
 
 

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -43,6 +43,8 @@ else:
             self.document = None
             self._current_node = None
             self._nodes = []
+            self.settings = docutils.frontend.OptionParser(
+                components=(docutils.parsers.rst.Parser,)).get_default_values()
 
         def esc(self, text):
             return text
@@ -50,9 +52,9 @@ else:
         def _parsed(self, text):
             document = docutils.utils.new_document(
                 "Schema",
-                settings=self.settings or docutils.frontend.OptionParser(
-                    components=(docutils.parsers.rst.Parser,)
-                    ).get_default_values())
+                settings=self.settings)
+
+
             parser = docutils.parsers.rst.Parser()
             parser.parse(text, document)
             return document.children
@@ -144,9 +146,7 @@ else:
         def body(self):
             self.document = self._current_node = docutils.utils.new_document(
                 "Schema",
-                settings=self.settings or docutils.frontend.OptionParser(
-                    components=(docutils.parsers.rst.Parser,)
-                    ).get_default_values())
+                settings=self.settings)
             yield
 
     class RstSchemaPrinter(AbstractSchemaPrinter):
@@ -160,14 +160,12 @@ else:
     class SchemaToRstDirective(Directive):
         required_arguments = 1
 
-        def run(self): # pragma: no cover
+        def run(self):
             schema = load_schema(self.arguments[0], True, 'component.xml')
 
             printer = RstSchemaPrinter(schema)
-            try:
-                printer.fmt.settings = self.state.document.settings
-            except AttributeError:
-                pass
+            printer.fmt.settings = self.state.document.settings
+
             printer.buildSchema()
 
             return printer.fmt.document.children

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -162,12 +162,17 @@ else:
         optional_arguments = 1
         option_spec = {
             'file': str,
+            'members': str
         }
         def run(self):
             schema = load_schema(self.arguments[0],
                                  True, self.options.get('file'))
 
-            printer = RstSchemaPrinter(schema)
+            members = ()
+            if 'members' in self.options:
+                members = self.options['members'].split()
+
+            printer = RstSchemaPrinter(schema, allowed_names=members)
             printer.fmt.settings = self.state.document.settings
 
             printer.buildSchema()

--- a/ZConfig/sphinx.py
+++ b/ZConfig/sphinx.py
@@ -15,7 +15,6 @@ from __future__ import print_function, absolute_import
 
 
 from contextlib import contextmanager
-import textwrap
 
 try:
     from docutils import nodes
@@ -154,10 +153,11 @@ else:
 
     class SchemaToRstDirective(Directive):
         required_arguments = 1
-        optional_arguments = 1
+        optional_arguments = 2
         option_spec = {
             'file': str,
-            'members': str
+            'members': str,
+            'excluded-members': str,
         }
         def run(self):
             schema = load_schema(self.arguments[0],
@@ -167,7 +167,11 @@ else:
             if 'members' in self.options:
                 members = self.options['members'].split()
 
-            printer = RstSchemaPrinter(schema, allowed_names=members)
+            excluded_members = ()
+            if 'excluded-members' in self.options:
+                excluded_members = self.options['excluded-members'].split()
+
+            printer = RstSchemaPrinter(schema, allowed_names=members, excluded_names=excluded_members)
             printer.fmt.settings = self.state.document.settings
 
             printer.buildSchema()

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -51,7 +51,13 @@ def run_transform(*args):
         return buf
     return schema2html.main(args) # pragma: no cover
 
-
+if schema2html.RstSchemaPrinter:
+    def run_transform_rst(*args):
+        args += ('--format', 'xml')
+        return run_transform(*args)
+else:
+    def run_transform_rst(*args):
+        pass
 
 class TestSchema2HTML(unittest.TestCase):
 
@@ -62,6 +68,7 @@ class TestSchema2HTML(unittest.TestCase):
     def test_schema_only(self):
         res = run_transform(input_file('simple.xml'))
         self.assertIn('</html>', res.getvalue())
+        run_transform_rst(input_file('simple.xml'))
 
     @with_stdin_from_input_file('simple.xml')
     def test_schema_only_redirect(self):
@@ -78,10 +85,12 @@ class TestSchema2HTML(unittest.TestCase):
                      'simplesections.xml',):
             res = run_transform(input_file(name))
             self.assertIn('</html>', res.getvalue())
+            run_transform_rst(input_file(name))
 
     def test_cover_logging_components(self):
         res = run_transform('--package', 'ZConfig.components.logger')
         self.assertIn('eventlog', res.getvalue())
+        run_transform_rst('--package', 'ZConfig.components.logger')
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -144,6 +144,25 @@ class TestRst(unittest.TestCase):
         # just that one file.
         self.assertNotIn("SMTPHandler", doc_text)
         self.assertIn("base-logger", doc_text)
+        self.assertIn("Base definition", doc_text)
+
+    def test_parse_package_limited_names(self):
+        text = """
+        Document
+        ========
+        .. zconfig:: ZConfig.components.logger
+            :members: syslog logfile
+        """
+        document = self._parse(text)
+        doc_text = document.astext()
+
+        # Check that it produced output, limited to
+        # just that one part of the tree
+        self.assertNotIn("SMTPHandler", doc_text)
+        self.assertIn("syslog", doc_text)
+        self.assertIn("SyslogHandlerFactory", doc_text)
+        self.assertIn("FileHandlerFactory", doc_text)
+
 
 
 def test_suite():

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -130,6 +130,7 @@ class TestRst(unittest.TestCase):
         doc_text = document.astext()
         # Check that it produced output
         self.assertIn("SMTPHandler", doc_text)
+        self.assertIn("Example:", doc_text)
 
     def test_parse_package_file(self):
         text = """
@@ -146,6 +147,7 @@ class TestRst(unittest.TestCase):
         self.assertNotIn("SMTPHandler", doc_text)
         self.assertIn("base-logger", doc_text)
         self.assertIn("Base definition", doc_text)
+        self.assertIn("Example:", doc_text)
 
     def test_parse_package_limited_names(self):
         text = """
@@ -174,7 +176,7 @@ class TestRst(unittest.TestCase):
         class FUT(RstSchemaFormatter):
             def __init__(self):
                 pass
-            def _parsed(self, text):
+            def _parsed(self, text, _):
                 return text
             def write(self, *texts):
                 written.extend(texts)

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -166,6 +166,27 @@ class TestRst(unittest.TestCase):
         self.assertIn("SyslogHandlerFactory", doc_text)
         self.assertIn("FileHandlerFactory", doc_text)
 
+    def test_parse_package_excluded_names(self):
+        text = """
+        Document
+        ========
+        .. zconfig:: ZConfig.components.logger
+            :members: ZConfig.logger.base-logger
+            :excluded-members: ZConfig.logger.handler
+        """
+        document = self._parse(text)
+        doc_text = document.astext()
+
+        # Check that it produced output, limited to
+        # just that one part of the tree
+        # In this case, the root base-logger, but the handlers subtree
+        # was excluded.
+        self.assertIn("zconfig.logger.base-logger", doc_text)
+        self.assertNotIn("SMTPHandler", doc_text)
+        self.assertNotIn("syslog", doc_text)
+        self.assertNotIn("SyslogHandlerFactory", doc_text)
+        self.assertNotIn("FileHandlerFactory", doc_text)
+
 
     def test_description_dedent(self):
         text = """No leading whitespace on this line.

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -106,7 +106,7 @@ class TestSchema2HTML(unittest.TestCase):
 
 class TestRst(unittest.TestCase):
 
-    def test_parse_package(self):
+    def _parse(self, text):
         document = docutils.utils.new_document(
             "Schema",
             settings=docutils.frontend.OptionParser(
@@ -114,17 +114,36 @@ class TestRst(unittest.TestCase):
                     ).get_default_values())
 
         parser = docutils.parsers.rst.Parser()
+        text = textwrap.dedent(text)
+        parser.parse(text, document)
+        return document
+
+    def test_parse_package(self):
         text = """
         Document
         ========
         .. zconfig:: ZConfig.components.logger
 
         """
-        text = textwrap.dedent(text)
-        parser.parse(text, document)
-        astext = document.astext()
+        document = self._parse(text)
+        doc_text = document.astext()
         # Check that it produced output
-        self.assertIn("SMTPHandler", astext)
+        self.assertIn("SMTPHandler", doc_text)
+
+    def test_parse_package_file(self):
+        text = """
+        Document
+        ========
+        .. zconfig:: ZConfig.components.logger
+            :file: base-logger.xml
+
+        """
+        document = self._parse(text)
+        doc_text = document.astext()
+        # Check that it produced output, limited to
+        # just that one file.
+        self.assertNotIn("SMTPHandler", doc_text)
+        self.assertIn("base-logger", doc_text)
 
 
 def test_suite():

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -40,6 +40,7 @@ from ZConfig import schema2html
 
 from ZConfig.sphinx import SchemaToRstDirective
 docutils.parsers.rst.directives.register_directive("zconfig", SchemaToRstDirective)
+from ZConfig.sphinx import RstSchemaFormatter
 
 from .support import input_file
 from .support import with_stdin_from_input_file
@@ -164,6 +165,27 @@ class TestRst(unittest.TestCase):
         self.assertIn("FileHandlerFactory", doc_text)
 
 
+    def test_description_dedent(self):
+        text = """No leading whitespace on this line.
+        But this line has whitespace.
+        As does this one.
+        """
+        written = []
+        class FUT(RstSchemaFormatter):
+            def __init__(self):
+                pass
+            def _parsed(self, text):
+                return text
+            def write(self, *texts):
+                written.extend(texts)
+        fut = FUT()
+        fut.description(text)
+
+        dedented = ("""No leading whitespace on this line.\n"""
+        """But this line has whitespace.\n"""
+        """As does this one.\n""")
+
+        self.assertEqual(written[0], dedented)
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.programoutput',
+    'ZConfig.schema2html',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.programoutput',
-    'ZConfig.schema2html',
+    'ZConfig.sphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/developing-with-zconfig.rst
+++ b/doc/developing-with-zconfig.rst
@@ -10,3 +10,4 @@
    standard-datatypes
    standard-components
    writing-components
+   documenting-components

--- a/doc/documenting-components.rst
+++ b/doc/documenting-components.rst
@@ -1,0 +1,69 @@
+
+.. _documenting-components:
+
+========================
+ Documenting Components
+========================
+
+ZConfig includes a docutils directive for documenting components that
+you create. This directive can function as a Sphinx extension if you
+include ``ZConfig.sphinx`` in the ``extensions`` value of your Sphinx
+configuration:
+
+.. code-block:: python
+
+  extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.interpsphinx',
+    'ZConfig.sphinx',
+  ]
+
+There is one directive:
+
+.. rst:directive:: .. zconfig:: <package-name>
+
+   .. versionadded:: 3.2.0
+
+   Document the components found in the Python package *package-name*.
+
+   By default, the contents of ``component.xml`` will be documented.
+   You can specify the ``:file:`` option to choose a different file
+   from that package.
+
+   Each component will have its name, type, and default value
+   documented. The description of the component will be rendered as
+   reStructuredText (and so can use directives like ``py:class:`` and
+   ``py:meth:`` to perform cross references). Any example for the
+   component will be rendered as a pre-formatted block.
+
+   All ZConfig components reachable will be documented, in the order
+   in which they are found. Often times, if your component extends
+   other components, this will produce too much documentation (it will
+   document the components you are extending in addition to the unique
+   aspects of your component). You can use the ``:members:`` and
+   ``:excluded-members:`` options to limit this.
+
+   Both of these options take a space-separated list of component
+   names. These options can be used together. When ``:members:`` is
+   given, only items that are explicitly named, or that are reachable
+   from such items, are documented. The ``:excluded-members:`` option
+   overrides this, causing any such members to be explicitly excluded.
+
+   These options are also useful for breaking the description of a
+   component up into multiple distinct sections, with narrative
+   documentation between them. For example, to document the main
+   logger component provided by ZConfig separately from each type of
+   handler ZConfig provides, the document might look like this:
+
+.. code-block:: rst
+
+   You can configure a logger and logging level with ZConfig:
+
+   .. zconfig:: ZConfig.components.logger
+       :members: ZConfig.logger.base-logger
+       :excluded-members: zconfig.logger.handler
+
+   ZConfig supports multiple different types of handlers for a given logger:
+
+   .. zconfig:: ZConfig.components.logger
+       :members: zconfig.logger.handler

--- a/doc/standard-components.rst
+++ b/doc/standard-components.rst
@@ -270,19 +270,11 @@ Configuring the email logger
 ----------------------------
 
 ZConfig has support for Python's :class:`logging.handlers.SMTPHandler`
-via the ``<email-notifier>`` handler::
+via the ``<email-notifier>`` handler.
 
-
-  <eventlog>
-    <email-notifier>
-      to sysadmin@example.com
-      to john@example.com
-      from zlog-user@example.com
-      level fatal
-      smtp-username john
-      smtp-password johnpw
-    </email-notifier>
-  </eventlog>
+.. zconfig:: ZConfig.components.logger
+     :file: handlers.xml
+     :members: email-notifier
 
 
 For details about the :class:`~logging.handlers.SMTPHandler` see the

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -19,6 +19,9 @@ Documenting Schemas
 ===================
 
 ZConfig also installs a tool called ``zconfig_schema2html`` that can
-print schemas in a simple HTML format:
+print schemas in a simple HTML format.
 
-  .. program-output:: zconfig_schema2html --help
+.. hint:: To document components in reStructuredText, e.g., with
+		 Sphinx, see :ref:`documenting-components`.
+
+.. program-output:: zconfig_schema2html --help

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -251,3 +251,4 @@ Configuring Logging
 ===================
 
 .. zconfig:: ZConfig.components.logger
+    :file: component.xml

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -250,5 +250,7 @@ For example, the value for ``key`` will evaluate to ``value``::
 Configuring Logging
 ===================
 
+Configuring handlers:
+
 .. zconfig:: ZConfig.components.logger
-    :file: component.xml
+    :members: ZConfig.logger.handler

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -246,17 +246,3 @@ For example, the value for ``key`` will evaluate to ``value``::
 
   %define name value
   key $name
-
-Configuring Logging
-===================
-
-Configuring loggers:
-
-.. zconfig:: ZConfig.components.logger
-    :members: ZConfig.logger.base-logger
-    :excluded-members: zconfig.logger.handler
-
-Configuring handlers:
-
-.. zconfig:: ZConfig.components.logger
-    :members: zconfig.logger.handler

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -253,4 +253,4 @@ Configuring Logging
 Configuring handlers:
 
 .. zconfig:: ZConfig.components.logger
-    :members: ZConfig.logger.handler
+    :members: ZConfig.logger.base-logger

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -246,3 +246,8 @@ For example, the value for ``key`` will evaluate to ``value``::
 
   %define name value
   key $name
+
+Configuring Logging
+===================
+
+.. zconfig:: ZConfig.components.logger

--- a/doc/using-zconfig.rst
+++ b/doc/using-zconfig.rst
@@ -250,7 +250,13 @@ For example, the value for ``key`` will evaluate to ``value``::
 Configuring Logging
 ===================
 
-Configuring handlers:
+Configuring loggers:
 
 .. zconfig:: ZConfig.components.logger
     :members: ZConfig.logger.base-logger
+    :excluded-members: zconfig.logger.handler
+
+Configuring handlers:
+
+.. zconfig:: ZConfig.components.logger
+    :members: zconfig.logger.handler

--- a/doc/writing-components.rst
+++ b/doc/writing-components.rst
@@ -41,7 +41,7 @@ Python class.
 
 The example component we build here will be in the :mod:`noise`
 package, but any package will do.  Components loadable using
-``%import`` must be contained in the 'component.xml' file;
+``%import`` must be contained in the ``component.xml`` file;
 alternate filenames may not be selected by the ``%import``
 construct.
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def alltests():
     return unittest.TestSuite(suites)
 
 tests_require = [
+    'docutils',
     'zope.testrunner',
 ]
 


### PR DESCRIPTION
Not ready to merge yet, but comments on the general approach are welcome.

This turned out to be surprisingly easy. It might be easier to understand viewing the commits one at a time, I tried to keep each step separate.

By keeping this code in the ZConfig project, it can document its own components (see the changed rst file, a start at including the logger documentation), and it has a better chance of staying in sync with changes in the ZConfig API/syntax. We don't take a dependency on sphinx explicitly, just docutils if its available (which it is when sphinx is installed).

TODO: 

- [x] Better tests. Complete coverage is not the same thing as a good test 😉 
- [x] Ability to specify only part of a component/schema to document (e.g., just the relstorage parts, not all of ZODB)
- [x] Finish surfacing nested types to the top-level (e.g., relstorage adapters)
- [x] Expose the `example` section in the output?
- [x] Document the directives.
