### PR TITLE
Use manuel to run doctest files.

### DIFF
--- a/ZConfig/tests/test_schemaless.py
+++ b/ZConfig/tests/test_schemaless.py
@@ -17,7 +17,8 @@ Test driver for ZConfig.schemaless.
 """
 __docformat__ = "reStructuredText"
 
-import doctest
+import manuel.doctest
+import manuel.testing
 import unittest
 
 from ZConfig.schemaless import Section
@@ -32,7 +33,9 @@ class TestSection(unittest.TestCase):
 def test_suite():
     return unittest.TestSuite([
         unittest.defaultTestLoader.loadTestsFromName(__name__),
-        doctest.DocFileSuite("schemaless.txt", package="ZConfig")
+        manuel.testing.TestSuite(
+            manuel.doctest.Manuel(),
+            '../schemaless.txt'),
     ])
 
 if __name__ == '__main__':

--- a/doc/using-logging.rst
+++ b/doc/using-logging.rst
@@ -7,26 +7,33 @@ framework. ZConfig provides one simple convenience function to do this:
 
 .. autofunction:: ZConfig.configureLoggers
 
-
 Suppose we have the following logging configuration in a file called ``simple-root-config.conf``:
 
 .. literalinclude:: simple-root-config.conf
    :language: xml
 
-We can load this file and pass its contents to ``configureLoggers``::
+We can load this file and pass its contents to ``configureLoggers``:
 
-    >>> from ZConfig import configureLoggers
-    >>> with open('simple-root-config.conf') as f:
-    ...   configureLoggers(f.read())
+.. code-block:: python
+
+    from ZConfig import configureLoggers
+    with open('simple-root-config.conf') as f:
+        configureLoggers(f.read())
+
+.. -> src
+  >>> import six
+  >>> six.exec_(src)
 
 When this returns, the root logger is configured to output messages
 logged at INFO or above to the console, as we can see in the following
-example::
+example:
+
+.. code-block:: pycon
 
     >>> from logging import getLogger
-    >>> getLogger().info('An info message')
-    INFO root An info message
-    >>> getLogger().debug('A debug message')
+    >>> getLogger().info('We see an info message')
+    INFO root We see an info message
+    >>> getLogger().debug('We do not see a debug message')
 
 A more common configuration would see STDOUT replaced with a path to
 the file into which log entries would be written.
@@ -73,17 +80,17 @@ If we load that configuration from ``root-and-child-config.conf``, we
 can expect this behaviour:
 
 ..
-  >>> tearDown(None)
+  >>> resetLoggers()
 
 .. code-block:: pycon
 
     >>> with open('root-and-child-config.conf') as f:
     ...     configureLoggers(f.read())
-    >>> getLogger().info('An info message')
-    INFO root An info message
-    >>> getLogger().debug('A debug message')
-    >>> getLogger('my.package').debug('A debug message')
-    DEBUG my.package A debug message
+    >>> getLogger().info('Here is another info message')
+    INFO root Here is another info message
+    >>> getLogger().debug('This debug message is hidden')
+    >>> getLogger('my.package').debug('The debug message for my.package shows')
+    DEBUG my.package The debug message for my.package shows
 
 .. _logging-handlers:
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def alltests():
 
 tests_require = [
     'docutils',
+    'manuel',
     'zope.testrunner',
 ]
 


### PR DESCRIPTION
We can't use the codeblock plugin for the using-logging test, instead
resorting to manually execing the captured source. This is because
stdout is not captured by a codeblock, so logging would be configured
to go to the *real* stdout, not one captured by the next doctest we
do (where we do want to use the doctest syntax) and our output
wouldn't get seen. This was maddening to figure out.

You can't use the capture plugin to capture literal includes, so we
still have the chdir hacks.

Overall it's not a whole lot of a win, at least right now.

I changed some of the text strings that we log to make them a bit more
descriptive. This was part of debuging too, but I think they're
better.

I ran into a problem doing 'python -m ZConfig.tests.test_readme' that
I added a workaround for.