### PR TITLE
Switch docs dependency back to sphinxcontrib-programoutput.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ options = dict(
     extras_require={
         'test': tests_require,
         'docs': [
-            'nti.sphinxcontrib-programoutput',
+            'sphinxcontrib-programoutput',
         ]
     },
 )


### PR DESCRIPTION
It has a maintainer again. Our fork has been rolled back in to it.

https://github.com/NextThought/sphinxcontrib-programoutput/issues/8