### PR TITLE
Replace almost all names that shadowed builtins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy-5.4.1
+    - pypy-5.6.0
     - pypy3.3-5.2-alpha1
 install:
     - pip install -U pip setuptools

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Change History for ZConfig
   documenting ZConfig components using their description and examples
   in Sphinx documentation.
 
+- Simplify internal schema processing of max and min occurrence
+  values. See https://github.com/zopefoundation/ZConfig/issues/15.
+
 3.1.0 (2015-10-17)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Change History for ZConfig
 - Simplify internal schema processing of max and min occurrence
   values. See https://github.com/zopefoundation/ZConfig/issues/15.
 
+- Almost all uses of ``type`` as a parameter name have been replaced
+  with ``type_`` to avoid shadowing a builtin. These were typically
+  not public APIs and weren't expected to be called with keyword
+  arguments so there should not be any user-visible changes. See
+  https://github.com/zopefoundation/ZConfig/issues/17
+
 3.1.0 (2015-10-17)
 ------------------
 

--- a/ZConfig/cfgparser.py
+++ b/ZConfig/cfgparser.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 """Configuration parser."""
-import sys
 
 import ZConfig
 import ZConfig.url
@@ -41,8 +40,7 @@ class ZConfigParser(object):
         if line:
             self.lineno += 1
             return False, line.strip()
-        else:
-            return True, None
+        return True, None
 
     def parse(self, section):
         done, line = self.nextline()
@@ -83,32 +81,32 @@ class ZConfigParser(object):
         m = _section_start_rx.match(text)
         if not m:
             self.error("malformed section header")
-        type, name = m.group('type', 'name')
-        type = self._normalize_case(type)
+        type_, name = m.group('type', 'name')
+        type_ = self._normalize_case(type_)
         if name:
             name = self._normalize_case(name)
         try:
-            newsect = self.context.startSection(section, type, name)
+            newsect = self.context.startSection(section, type_, name)
         except ZConfig.ConfigurationError as e:
             self.error(e.message)
 
         if isempty:
-            self.context.endSection(section, type, name, newsect)
+            self.context.endSection(section, type_, name, newsect)
             return section
-        else:
-            self.stack.append((type, name, section))
-            return newsect
+
+        self.stack.append((type_, name, section))
+        return newsect
 
     def end_section(self, section, rest):
         if not self.stack:
             self.error("unexpected section end")
-        type = self._normalize_case(rest.rstrip())
+        type_ = self._normalize_case(rest.rstrip())
         opentype, name, prevsection = self.stack.pop()
-        if type != opentype:
+        if type_ != opentype:
             self.error("unbalanced section end")
         try:
             self.context.endSection(
-                prevsection, type, name, section)
+                prevsection, type_, name, section)
         except ZConfig.ConfigurationError as e:
             self.error(e.args[0])
         return prevsection

--- a/ZConfig/cmdline.py
+++ b/ZConfig/cmdline.py
@@ -24,8 +24,6 @@ Each setting is given by a value specifier string, as described by
 :meth:`ExtendedConfigLoader.addOption`.
 """
 
-import sys
-
 import ZConfig
 import ZConfig.loader
 import ZConfig.matcher
@@ -141,13 +139,12 @@ class OptionBag(object):
         if L:
             del self.keypairs[name]
             return L
-        else:
-            return []
+        return []
 
     def keys(self):
         return self.keypairs.keys()
 
-    def get_section_info(self, type, name):
+    def get_section_info(self, type_, name):
         L = []  # what pertains to the child section
         R = []  # what we keep
         for item in self.sectitems:
@@ -156,15 +153,13 @@ class OptionBag(object):
             bk = self.basic_key(s, pos)
             if name and self._normalize_case(s) == name:
                 L.append((optpath[1:], val, pos))
-            elif bk == type: # pragma: no cover
+            elif bk == type_: # pragma: no cover
                 L.append((optpath[1:], val, pos))
             else:
                 R.append(item)
         if L:
             self.sectitems[:] = R
-            return OptionBag(self.schema, self.schema.gettype(type), L)
-        else:
-            return None
+            return OptionBag(self.schema, self.schema.gettype(type_), L)
 
     def finish(self):
         if self.sectitems or self.keypairs:
@@ -190,9 +185,9 @@ class MatcherMixin(object):
             return
         ZConfig.matcher.BaseMatcher.addValue(self, key, value, position)
 
-    def createChildMatcher(self, type, name):
-        sm = ZConfig.matcher.BaseMatcher.createChildMatcher(self, type, name)
-        bag = self.optionbag.get_section_info(type.name, name)
+    def createChildMatcher(self, type_, name):
+        sm = ZConfig.matcher.BaseMatcher.createChildMatcher(self, type_, name)
+        bag = self.optionbag.get_section_info(type_.name, name)
         if bag is not None:
             sm = ExtendedSectionMatcher(
                 sm.info, sm.type, sm.name, sm.handlers)

--- a/ZConfig/datatypes.py
+++ b/ZConfig/datatypes.py
@@ -34,13 +34,12 @@ import re
 import sys
 import datetime
 
-from ZConfig._compat import text_type
-from ZConfig._compat import binary_type
-
 try:
     unicode
 except NameError:
+    # Python 3
     have_unicode = False
+    from functools import reduce
 else:
     have_unicode = True
 
@@ -331,11 +330,11 @@ def existing_file(v):
 
 def existing_dirpath(v):
     nv = os.path.expanduser(v)
-    dir = os.path.dirname(nv)
-    if not dir:
+    dirname = os.path.dirname(nv)
+    if not dirname:
         # relative pathname with no directory component
         return nv
-    if os.path.isdir(dir):
+    if os.path.isdir(dirname):
         return nv
     raise ValueError('The directory named as part of the path %s '
                      'does not exist.' % v)
@@ -349,12 +348,11 @@ class SuffixMultiplier(object):
         self._d = d
         self._default = default
         # all keys must be the same size
-        self._keysz = None
-        for k in d.keys():
-            if self._keysz is None:
-                self._keysz = len(k)
-            else:
-                assert self._keysz == len(k)
+        def check(a, b):
+            if len(a) != len(b):
+                raise ValueError("suffix length mismatch")
+            return a
+        self._keysz = len(reduce(check, d))
 
     def __call__(self, v):
         v = v.lower()

--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -64,13 +64,15 @@ class BaseInfo(object):
 
     def __init__(self, name, datatype, minOccurs, maxOccurs, handler,
                  attribute):
-        if maxOccurs is not None:
-            if maxOccurs < 1:
-                raise ZConfig.SchemaError(
-                    "maxOccurs must be at least 1")
-            if minOccurs is not None and minOccurs > maxOccurs:
-                raise ZConfig.SchemaError(
-                    "minOccurs cannot be more than maxOccurs")
+        assert maxOccurs is not None, "Use Unbounded for an upper bound, not None"
+        assert minOccurs is not None, "Use 0 for a lower bound, not None"
+
+        if maxOccurs < 1:
+            raise ZConfig.SchemaError(
+                "maxOccurs must be at least 1")
+        if minOccurs > maxOccurs:
+            raise ZConfig.SchemaError(
+                "minOccurs cannot be more than maxOccurs")
         self.name = name
         self.datatype = datatype
         self.minOccurs = minOccurs
@@ -98,7 +100,6 @@ class BaseKeyInfo(AbstractBaseClass, BaseInfo):
 
     def __init__(self, name, datatype, minOccurs, maxOccurs, handler,
                  attribute):
-        assert minOccurs is not None
         BaseInfo.__init__(self, name, datatype, minOccurs, maxOccurs,
                           handler, attribute)
         self._finished = False
@@ -221,8 +222,6 @@ class SectionInfo(BaseInfo):
         # handler     - handler name called when value(s) must take effect,
         #               or None
         # attribute   - name of the attribute on the SectionValue object
-        assert maxOccurs is not None
-        # because we compare it to 1 which is a Py3 error
         if maxOccurs > 1:
             if name not in ('*', '+'):
                 raise ZConfig.SchemaError(

--- a/ZConfig/info.py
+++ b/ZConfig/info.py
@@ -254,7 +254,7 @@ class SectionInfo(BaseInfo):
         if name == "*" or name == "+":
             return False
         elif self.name == "+":
-            return name and True or False
+            return True if name else False
         elif self.name == "*":
             return True
         else:
@@ -282,8 +282,8 @@ class AbstractType(object):
     def __iter__(self):
         return iter(self._subtypes.items())
 
-    def addsubtype(self, type):
-        self._subtypes[type.name] = type
+    def addsubtype(self, type_):
+        self._subtypes[type_.name] = type_
 
     def getsubtype(self, name):
         try:
@@ -392,7 +392,7 @@ class SectionType(object):
                         stack.append(t)
         return list(d.keys())
 
-    def getsectioninfo(self, type, name):
+    def getsectioninfo(self, type_, name):
         for key, info in self._children:
             if key:
                 if key == name:
@@ -402,29 +402,29 @@ class SectionType(object):
                     st = info.sectiontype
                     if st.isabstract():
                         try:
-                            st = st.getsubtype(type)
+                            st = st.getsubtype(type_)
                         except ZConfig.ConfigurationError: # pragma: no cover
                             raise ZConfig.ConfigurationError(
                                 "section type %s not allowed for name %s"
-                                % (repr(type), repr(key)))
-                    if not st.name == type:
+                                % (repr(type_), repr(key)))
+                    if st.name != type_:
                         raise ZConfig.ConfigurationError(
                             "name %s must be used for a %s section"
                             % (repr(name), repr(st.name)))
                     return info
             # else must be a sectiontype or an abstracttype:
-            elif info.sectiontype.name == type:
+            elif info.sectiontype.name == type_:
                 if not (name or info.allowUnnamed()):
                     raise ZConfig.ConfigurationError(
-                        repr(type) + " sections must be named")
+                        repr(type_) + " sections must be named")
                 return info
             elif info.sectiontype.isabstract():
                 st = info.sectiontype
-                if st.name == type: # pragma: no cover
+                if st.name == type_: # pragma: no cover
                     raise ZConfig.ConfigurationError(
                         "cannot define section with an abstract type")
                 try:
-                    st = st.getsubtype(type)
+                    st = st.getsubtype(type_)
                 except ZConfig.ConfigurationError: # pragma: no cover
                     # not this one; maybe a different one
                     pass
@@ -432,7 +432,7 @@ class SectionType(object):
                     return info
         raise ZConfig.ConfigurationError(
             "no matching section defined for type='%s', name='%s'" % (
-            type, name))
+            type_, name))
 
     def isabstract(self):
         return False

--- a/ZConfig/schema.py
+++ b/ZConfig/schema.py
@@ -367,7 +367,7 @@ class BaseParser(xml.sax.ContentHandler):
     def start_section(self, attrs):
         sectiontype = self.get_sectiontype(attrs)
         handler = self.get_handler(attrs)
-        min = self.get_required(attrs) and 1 or 0
+        min = 1 if self.get_required(attrs) else 0
         any, name, attribute = self.get_name_info(attrs, "section", "*")
         if any and not attribute: # pragma: no cover
             # It seems like this is handled by get_name_info.
@@ -410,7 +410,7 @@ class BaseParser(xml.sax.ContentHandler):
 
     def start_key(self, attrs):
         name, datatype, handler, attribute = self.get_key_info(attrs, "key")
-        min = self.get_required(attrs) and 1 or 0
+        min = 1 if self.get_required(attrs) else 0
         key = info.KeyInfo(name, datatype, min, handler, attribute)
         if "default" in attrs:
             if min:

--- a/ZConfig/schemaless.py
+++ b/ZConfig/schemaless.py
@@ -93,12 +93,12 @@ class Context(object):
         self.top = Section()
         self.sections = []
 
-    def startSection(self, container, type, name):
-        newsec = Section(type, name)
+    def startSection(self, container, type_, name):
+        newsec = Section(type_, name)
         container.sections.append(newsec)
         return newsec
 
-    def endSection(self, container, type, name, newsect):
+    def endSection(self, container, type_, name, newsect):
         pass
 
     def importSchemaComponent(self, pkgname):

--- a/ZConfig/tests/test_config.py
+++ b/ZConfig/tests/test_config.py
@@ -46,9 +46,9 @@ class ConfigurationTestCase(unittest.TestCase):
         sio = StringIO(text)
         return self.loadfile(sio)
 
-    def loadfile(self, file):
+    def loadfile(self, file_or_path):
         schema = self.get_schema()
-        self.conf, self.handlers = ZConfig.loadConfigFile(schema, file)
+        self.conf, self.handlers = ZConfig.loadConfigFile(schema, file_or_path)
         return self.conf
 
     def check_simple_gets(self, conf):
@@ -245,10 +245,10 @@ class ConfigurationTestCase(unittest.TestCase):
 
     def test_load_from_relpath(self):
         fn = self.write_tempfile()
-        dir, name = os.path.split(fn)
+        dirname, name = os.path.split(fn)
         pwd = os.getcwd()
         try:
-            os.chdir(dir)
+            os.chdir(dirname)
             self.check_load_from_path(name)
         finally:
             os.chdir(pwd)

--- a/ZConfig/tests/test_info.py
+++ b/ZConfig/tests/test_info.py
@@ -38,7 +38,7 @@ class InfoMixin(object):
     Class = None
 
     default_kwargs = {'name': '', 'datatype': None, 'handler': None,
-                      'minOccurs': None, 'maxOccurs': None, 'attribute': None}
+                      'minOccurs': 0, 'maxOccurs': Unbounded, 'attribute': None}
 
     def make_one(self, **kwargs):
         args = self.default_kwargs.copy()
@@ -54,7 +54,7 @@ class BaseInfoTestCase(InfoMixin, unittest.TestCase):
         self.assertRaisesRegexp(SchemaError,
                                 'maxOccurs',
                                 self.make_one,
-                                maxOccurs=0)
+                                maxOccurs=0, minOccurs=0)
 
         # This case doesn't really make sense
         self.assertRaisesRegexp(SchemaError,

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27,py33,py34,py35,py36,pypy
 
 [testenv]
 commands =
     python setup.py -q test -q
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
-     zope.testrunner
+     .[test]
 
 [testenv:coverage]
 basepython =


### PR DESCRIPTION
(Accidentally including #30 right now.)

Fixes #17

There are a few that are still left because they were used as keyword arguments with defaults or I couldn't think of a better name.

I also fixed a few other pylint errors/warnings that were nearby the names.

Current list:
```
************* Module ZConfig.cfgparser
W:103, 8: Redefining built-in 'type' (redefined-builtin)
************* Module ZConfig.datatypes
W: 42, 4: Redefining built-in 'reduce' (redefined-builtin)
W: 80,35: Redefining built-in 'min' (redefined-builtin)
W: 80,45: Redefining built-in 'max' (redefined-builtin)
************* Module ZConfig.loader
W: 53,19: Redefining built-in 'file' (redefined-builtin)
W: 97,27: Redefining built-in 'file' (redefined-builtin)
W:140,29: Redefining built-in 'file' (redefined-builtin)
W:162,23: Redefining built-in 'file' (redefined-builtin)
W:210,12: Redefining built-in 'file' (redefined-builtin)
W:513,23: Redefining built-in 'file' (redefined-builtin)
************* Module ZConfig.schemaless
W: 23,19: Redefining built-in 'file' (redefined-builtin)
W: 31,23: Redefining built-in 'file' (redefined-builtin)
W: 39,23: Redefining built-in 'type' (redefined-builtin)
```