### PR TITLE
Ignore sys.argv in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,15 @@
 [run]
+# This is not as helpful as it may seem, because the parent directory is
+# likely also named ZConfig, so this matches things like
+# /path/to/ZConfig/.tox/py*/lib/*
 source = ZConfig
+
+# datatypes.py is dynamically-created in a temporary directory and then
+# removed, which makes coverage reporting unhappy.
+omit =
+  */datatypes.py
+  .tox/*
+  ZConfig/tests/*
 
 [report]
 # Coverage is run on Py2 and Py3

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ parts/
 doc/_build
 htmlcov/
 .coverage
+coverage.xml
+nosetests.xml

--- a/ZConfig/schema2html.py
+++ b/ZConfig/schema2html.py
@@ -86,7 +86,7 @@ class HtmlSchemaPrinter(AbstractSchemaPrinter):
     _schema_formatter = HtmlSchemaFormatter
 
 def main(argv=None):
-    argv = argv or sys.argv[1:]
+    argv = argv if argv is not None else sys.argv[1:]
 
     argparser = argparse.ArgumentParser(
         description="Print an HTML version of a schema")

--- a/ZConfig/tests/test_schema2html.py
+++ b/ZConfig/tests/test_schema2html.py
@@ -74,10 +74,6 @@ else:
 
 class TestSchema2HTML(unittest.TestCase):
 
-    def test_no_schema(self):
-        self.assertRaises(SystemExit,
-                          run_transform)
-
     def test_schema_only(self):
         res = run_transform(input_file('simple.xml'))
         self.assertIn('</html>', res.getvalue())

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,6 @@ deps =
 basepython =
     python2.7
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y ZConfig
-    pip install -e .[test]
     coverage run setup.py -q test -q
     coverage report -m
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 #   So, we uninstall that from the environment, and then install the editable
 #   version, before running nosetests.
     pip uninstall -y ZConfig
-    pip install -e .
+    pip install -e .[test]
     nosetests --with-xunit --with-xcoverage
 deps =
     nose

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ commands =
 #   version, before running nosetests.
     pip uninstall -y ZConfig
     pip install -e .[test]
-    nosetests --with-xunit --with-xcoverage
+    coverage run setup.py -q test -q
+    coverage report -m
 deps =
-    nose
     coverage
-    nosexcover
+    {[testenv]deps}


### PR DESCRIPTION
Fixes #34.

Also fixes `tox -e coverage` which was rather broken for me:

- installs test dependencies (such as manuel) so tests won't break

- adds omit patterns to .coveragerc so coverage report won't break and won't
  report about files in .tox/py*/lib/*

- drops nose + nose-xcover and all its problems and workarounds and uses
  coverage run directly