### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:
     - 3.6
     - pypy
     - pypy3
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+          sudo: true
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,16 @@ Change History for ZConfig
 3.3.0 (unreleased)
 ------------------
 
+- Drop support for Python 3.3.
+
+- Add support for Python 3.7.
+
 - Drop support for 'python setup.py test'. See `issue 38
   <https://github.com/zopefoundation/ZConfig/issues/38>`_.
 
 - Add support for ``example`` in ``section`` and ``multisection``, and
   include those examples in generated documentation. See
   https://github.com/zopefoundation/ZConfig/pull/5.
-
-- Drop support for Python 3.3.
 
 - Fix configuration loaders to decode byte data using UTF-8 instead of
   the default encoding (usually ASCII). See `issue 37

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -30,6 +30,9 @@ from ZConfig.components.logger import loghandler
 from ZConfig._compat import NStringIO as StringIO
 from ZConfig._compat import maxsize
 
+from ZConfig.tests.support import TestHelper
+
+
 class CustomFormatter(logging.Formatter):
     def formatException(self, ei):
         """Format and return the exception information as a string.
@@ -47,7 +50,7 @@ def read_file(filename):
         return f.read()
 
 
-class LoggingTestHelper:
+class LoggingTestHelper(TestHelper):
 
     # Not derived from unittest.TestCase; some test runners seem to
     # think that means this class contains tests.
@@ -229,7 +232,7 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
             "</eventlog>" % fn)
 
         # Mising old-files
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "old-files must be set",
             self.check_simple_logger,
@@ -242,7 +245,7 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
             "  </logfile>\n"
             "</eventlog>" % fn)
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "max-bytes or when must be set",
             self.check_simple_logger,
@@ -683,13 +686,13 @@ class TestReopeningLogfiles(TestReopeningRotatingLogfiles):
 
         self.assertEqual(calls, ["acquire", "release"])
 
-class TestFunctions(unittest.TestCase):
+class TestFunctions(TestHelper, unittest.TestCase):
 
     def test_log_format_bad(self):
-        self.assertRaisesRegexp(ValueError,
-                                "Invalid log format string",
-                                handlers.log_format,
-                                "%{no-such-key}s")
+        self.assertRaisesRegex(ValueError,
+                               "Invalid log format string",
+                               handlers.log_format,
+                               "%{no-such-key}s")
 
     def test_resolve_deep(self):
         old_mod = None
@@ -708,15 +711,15 @@ class TestFunctions(unittest.TestCase):
                 sys.modules['logging.handlers'] = old_mod
 
     def test_http_handler_url(self):
-        self.assertRaisesRegexp(ValueError,
-                                'must be an http',
-                                handlers.http_handler_url, 'file://foo/baz')
-        self.assertRaisesRegexp(ValueError,
-                                'must specify a location',
-                                handlers.http_handler_url, 'http://')
-        self.assertRaisesRegexp(ValueError,
-                                'must specify a path',
-                                handlers.http_handler_url, 'http://server')
+        self.assertRaisesRegex(ValueError,
+                               'must be an http',
+                               handlers.http_handler_url, 'file://foo/baz')
+        self.assertRaisesRegex(ValueError,
+                               'must specify a location',
+                               handlers.http_handler_url, 'http://')
+        self.assertRaisesRegex(ValueError,
+                               'must specify a path',
+                               handlers.http_handler_url, 'http://server')
 
         v = handlers.http_handler_url("http://server/path;param?q=v#fragment")
         self.assertEqual(v, ('server', '/path;param?q=v#fragment'))

--- a/ZConfig/schema2html.py
+++ b/ZConfig/schema2html.py
@@ -15,7 +15,11 @@ from __future__ import print_function
 
 import argparse
 from contextlib import contextmanager
-import cgi
+try:
+    import html
+except ImportError:
+    # Py2
+    import cgi as html
 import sys
 
 from ZConfig._schema_utils import AbstractSchemaPrinter
@@ -27,7 +31,7 @@ from ZConfig.sphinx import RstSchemaPrinter
 class HtmlSchemaFormatter(AbstractSchemaFormatter):
 
     def esc(self, x):
-        return cgi.escape(str(x))
+        return html.escape(str(x))
 
     @contextmanager
     def _simple_tag(self, tag):

--- a/ZConfig/tests/support.py
+++ b/ZConfig/tests/support.py
@@ -17,6 +17,7 @@
 import contextlib
 import os
 import sys
+from unittest import TestCase
 
 import ZConfig
 
@@ -58,6 +59,8 @@ class TestHelper(object):
 
     # Not derived from unittest.TestCase; some test runners seem to
     # think that means this class contains tests.
+
+    assertRaisesRegex = getattr(TestCase, 'assertRaisesRegex', TestCase.assertRaisesRegexp)
 
     def load_both(self, schema_url, conf_url):
         schema = self.load_schema(schema_url)

--- a/ZConfig/tests/support.py
+++ b/ZConfig/tests/support.py
@@ -17,7 +17,7 @@
 import contextlib
 import os
 import sys
-from unittest import TestCase
+import unittest
 
 import ZConfig
 
@@ -60,7 +60,8 @@ class TestHelper(object):
     # Not derived from unittest.TestCase; some test runners seem to
     # think that means this class contains tests.
 
-    assertRaisesRegex = getattr(TestCase, 'assertRaisesRegex', TestCase.assertRaisesRegexp)
+    assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegex',
+                                unittest.TestCase.assertRaisesRegexp)
 
     def load_both(self, schema_url, conf_url):
         schema = self.load_schema(schema_url)

--- a/ZConfig/tests/test_cmdline.py
+++ b/ZConfig/tests/test_cmdline.py
@@ -91,20 +91,20 @@ class CommandLineTest(ZConfig.tests.support.TestHelper, unittest.TestCase):
         # Ignore foo for now; it's not really important *when* it fails.
 
         # ValueErrors are converted into ConfigurationSyntaxErrors
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                "could not convert",
-                                foo.basic_key,
-                                'invalid name', ('<place>', 1,))
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               "could not convert",
+                               foo.basic_key,
+                               'invalid name', ('<place>', 1,))
 
         # missing keys return empty lists
         self.assertEqual(foo.get_key('no such key'), [])
 
         # VE for matchers do the same conversion
         matcher = loader.createSchemaMatcher()
-        self.assertRaisesRegexp(ZConfig.DataConversionError,
-                                "value did not match",
-                                matcher.addValue,
-                                'invalid name', 'value', (1, 1, '<place>'))
+        self.assertRaisesRegex(ZConfig.DataConversionError,
+                               "value did not match",
+                               matcher.addValue,
+                               'invalid name', 'value', (1, 1, '<place>'))
 
 
     simple_schema = None
@@ -193,28 +193,21 @@ class CommandLineTest(ZConfig.tests.support.TestHelper, unittest.TestCase):
         self.assertEqual(conf.s2.k3, ["value1", "value2", "value3", "value4"])
 
         self.clopts = [("path/that/dne=foo",)]
-        self.assertRaisesRegexp(ZConfig.ConfigurationError,
-                                "not all command line options were consumed",
-                                self.load_config_text,
-                                schema, "<st s1/>")
+        self.assertRaisesRegex(ZConfig.ConfigurationError,
+                               "not all command line options were consumed",
+                               self.load_config_text,
+                               schema, "<st s1/>")
 
     def test_bad_overrides(self):
         schema = self.get_simple_schema()
         self.clopts = [('',)]
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                "invalid configuration specifier",
-                                self.create_config_loader,
-                                schema)
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               "invalid configuration specifier",
+                               self.create_config_loader,
+                               schema)
 
         self.clopts = [('double//slashes=value',)]
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                "not allowed in an option path",
-                                self.create_config_loader,
-                                schema)
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               "not allowed in an option path",
+                               self.create_config_loader,
+                               schema)

--- a/ZConfig/tests/test_config.py
+++ b/ZConfig/tests/test_config.py
@@ -19,10 +19,11 @@ import unittest
 import ZConfig
 
 from ZConfig.tests.support import CONFIG_BASE
+from ZConfig.tests.support import TestHelper
 
 from ZConfig._compat import NStringIO as StringIO
 
-class ConfigurationTestCase(unittest.TestCase):
+class ConfigurationTestCase(TestHelper, unittest.TestCase):
 
     schema = None
 
@@ -171,51 +172,51 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertNotIn('line', str(exc))
 
     def test_bad_directive(self):
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'unknown directive',
-                                self.loadtext, '%not a directive')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'unknown directive',
+                               self.loadtext, '%not a directive')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'missing or unrecognized',
-                                self.loadtext, '%')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'missing or unrecognized',
+                               self.loadtext, '%')
 
     def test_bad_key(self):
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'malformed configuration data',
-                                self.loadtext, '(int-var')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'malformed configuration data',
+                               self.loadtext, '(int-var')
 
     def test_bad_section(self):
         self.schema = ZConfig.loadSchema(CONFIG_BASE + "simplesections.xml")
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'unexpected section end',
-                                self.loadtext, '</close>')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'unexpected section end',
+                               self.loadtext, '</close>')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'unbalanced section end',
-                                self.loadtext, '<section>\n</close>')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'unbalanced section end',
+                               self.loadtext, '<section>\n</close>')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'unclosed sections not allowed',
-                                self.loadtext, '<section>\n')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'unclosed sections not allowed',
+                               self.loadtext, '<section>\n')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'malformed section header',
-                                self.loadtext, '<section()>\n</close>')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'malformed section header',
+                               self.loadtext, '<section()>\n</close>')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'malformed section end',
-                                self.loadtext, '<section>\n</section')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'malformed section end',
+                               self.loadtext, '<section>\n</section')
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                'malformed section start',
-                                self.loadtext, '<section')
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               'malformed section start',
+                               self.loadtext, '<section')
 
         # ConfigLoader.endSection raises this and it is recaught and changed to a
         # SyntaxError
-        self.assertRaisesRegexp(ZConfig.ConfigurationSyntaxError,
-                                "no values for",
-                                self.loadtext,
-                                "<hasmin foo>\n</hasmin>")
+        self.assertRaisesRegex(ZConfig.ConfigurationSyntaxError,
+                               "no values for",
+                               self.loadtext,
+                               "<hasmin foo>\n</hasmin>")
 
     def test_configuration_error_str(self):
 

--- a/ZConfig/tests/test_datatypes.py
+++ b/ZConfig/tests/test_datatypes.py
@@ -23,6 +23,8 @@ import unittest
 
 import ZConfig.datatypes
 
+from ZConfig.tests.support import TestHelper
+
 here = os.path.abspath(__file__)
 
 try:
@@ -383,7 +385,7 @@ class DatatypeTestCase(unittest.TestCase):
 
         raises(TypeError, convert, '1y')
 
-class RegistryTestCase(unittest.TestCase):
+class RegistryTestCase(TestHelper, unittest.TestCase):
 
     def test_registry_does_not_mask_toplevel_imports(self):
         old_sys_path = sys.path[:]
@@ -406,24 +408,24 @@ class RegistryTestCase(unittest.TestCase):
 
     def test_register_shadow(self):
         reg = ZConfig.datatypes.Registry()
-        self.assertRaisesRegexp(ValueError,
-                                "conflicts with built-in type",
-                                reg.register,
-                                'integer', None)
+        self.assertRaisesRegex(ValueError,
+                               "conflicts with built-in type",
+                               reg.register,
+                               'integer', None)
 
         reg.register("foobar", None)
-        self.assertRaisesRegexp(ValueError,
-                                "already registered",
-                                reg.register,
-                                'foobar', None)
+        self.assertRaisesRegex(ValueError,
+                               "already registered",
+                               reg.register,
+                               'foobar', None)
 
     def test_get_fallback_basic_key(self):
         reg = ZConfig.datatypes.Registry({})
         self.assertIsNone(reg._basic_key)
-        self.assertRaisesRegexp(ValueError,
-                                "unloadable datatype name",
-                                reg.get,
-                                'integer')
+        self.assertRaisesRegex(ValueError,
+                               "unloadable datatype name",
+                               reg.get,
+                               'integer')
         self.assertIsNotNone(reg._basic_key)
 
 TEST_DATATYPE_SOURCE = """
@@ -431,10 +433,3 @@ TEST_DATATYPE_SOURCE = """
 
 my_sample_datatype = 42
 """
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/ZConfig/tests/test_info.py
+++ b/ZConfig/tests/test_info.py
@@ -26,6 +26,9 @@ from ZConfig.info import AbstractType
 from ZConfig.info import SectionType
 from ZConfig.info import SchemaType
 
+from ZConfig.tests.support import TestHelper
+
+
 class UnboundTestCase(unittest.TestCase):
 
     def test_order(self):
@@ -33,7 +36,7 @@ class UnboundTestCase(unittest.TestCase):
         self.assertFalse(Unbounded > Unbounded)
         self.assertEqual(Unbounded, Unbounded)
 
-class InfoMixin(object):
+class InfoMixin(TestHelper):
 
     Class = None
 
@@ -51,17 +54,17 @@ class BaseInfoTestCase(InfoMixin, unittest.TestCase):
     Class = BaseInfo
 
     def test_constructor_error(self):
-        self.assertRaisesRegexp(SchemaError,
-                                'maxOccurs',
-                                self.make_one,
-                                maxOccurs=0, minOccurs=0)
+        self.assertRaisesRegex(SchemaError,
+                               'maxOccurs',
+                               self.make_one,
+                               maxOccurs=0, minOccurs=0)
 
         # This case doesn't really make sense
-        self.assertRaisesRegexp(SchemaError,
-                                'minOccurs',
-                                self.make_one,
-                                maxOccurs=1,
-                                minOccurs=2)
+        self.assertRaisesRegex(SchemaError,
+                               'minOccurs',
+                               self.make_one,
+                               maxOccurs=1,
+                               minOccurs=2)
 
     def test_repr(self):
         # just doesn't raise
@@ -87,10 +90,10 @@ class BaseKeyInfoTestCase(InfoMixin, unittest.TestCase):
 
     def test_adddefaultc(self):
         info = self.make_one(name='foo', minOccurs=1)
-        self.assertRaisesRegexp(SchemaError,
-                                'unexpected key for default',
-                                info.adddefault,
-                                None, None, key='key')
+        self.assertRaisesRegex(SchemaError,
+                               'unexpected key for default',
+                               info.adddefault,
+                               None, None, key='key')
 
 class KeyInfoTestCase(InfoMixin, unittest.TestCase):
 
@@ -101,10 +104,10 @@ class KeyInfoTestCase(InfoMixin, unittest.TestCase):
     def test_add_with_default(self):
         info = self.make_one(minOccurs=1, name='name')
         info.adddefault('value', None)
-        self.assertRaisesRegexp(SchemaError,
-                                'cannot set more than one',
-                                info.adddefault,
-                                'value', None)
+        self.assertRaisesRegex(SchemaError,
+                               'cannot set more than one',
+                               info.adddefault,
+                               'value', None)
 
 class SectionInfoTestCase(InfoMixin, unittest.TestCase):
 
@@ -121,14 +124,14 @@ class SectionInfoTestCase(InfoMixin, unittest.TestCase):
     default_kwargs['sectiontype'] = MockSectionType
 
     def test_constructor_error(self):
-        self.assertRaisesRegexp(SchemaError,
-                                'must use a name',
-                                self.make_one,
-                                name='name', maxOccurs=2)
-        self.assertRaisesRegexp(SchemaError,
-                                'must specify a target attribute',
-                                self.make_one,
-                                name='*', maxOccurs=2)
+        self.assertRaisesRegex(SchemaError,
+                               'must use a name',
+                               self.make_one,
+                               name='name', maxOccurs=2)
+        self.assertRaisesRegex(SchemaError,
+                               'must specify a target attribute',
+                               self.make_one,
+                               name='*', maxOccurs=2)
 
     def test_misc(self):
         info = self.make_one(maxOccurs=1)
@@ -148,7 +151,7 @@ class AbstractTypeTestCase(unittest.TestCase):
         t.addsubtype(self)
         self.assertTrue(t.hassubtype('foo'))
 
-class SectionTypeTestCase(unittest.TestCase):
+class SectionTypeTestCase(TestHelper, unittest.TestCase):
 
     def make_one(self, name='', keytype=None, valuetype=None,
                  datatype=None, registry={}, types=None):
@@ -156,10 +159,10 @@ class SectionTypeTestCase(unittest.TestCase):
 
     def test_getinfo_no_key(self):
         info = self.make_one()
-        self.assertRaisesRegexp(ConfigurationError,
-                                "cannot match a key without a name",
-                                info.getinfo,
-                                None)
+        self.assertRaisesRegex(ConfigurationError,
+                               "cannot match a key without a name",
+                               info.getinfo,
+                               None)
 
     def test_required_types_with_name(self):
         info = self.make_one(name='foo')
@@ -176,17 +179,17 @@ class SectionTypeTestCase(unittest.TestCase):
 
         info._children.append(('foo', child))
 
-        self.assertRaisesRegexp(ConfigurationError,
-                                'already in use for key',
-                                info.getsectioninfo,
-                                None, 'foo')
+        self.assertRaisesRegex(ConfigurationError,
+                               'already in use for key',
+                               info.getsectioninfo,
+                               None, 'foo')
 
-        self.assertRaisesRegexp(ConfigurationError,
-                                'no matching section',
-                                info.getsectioninfo,
-                                None, 'baz')
+        self.assertRaisesRegex(ConfigurationError,
+                               'no matching section',
+                               info.getsectioninfo,
+                               None, 'baz')
 
-class SchemaTypeTestCase(unittest.TestCase):
+class SchemaTypeTestCase(TestHelper, unittest.TestCase):
 
     def test_various(self):
         class Mock(object):
@@ -207,14 +210,7 @@ class SchemaTypeTestCase(unittest.TestCase):
             schema.deriveSectionType(schema, None, None, None, None)
 
         schema.addComponent('name')
-        self.assertRaisesRegexp(SchemaError,
-                                'already have component',
-                                schema.addComponent,
-                                'name')
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+        self.assertRaisesRegex(SchemaError,
+                               'already have component',
+                               schema.addComponent,
+                               'name')

--- a/ZConfig/tests/test_loader.py
+++ b/ZConfig/tests/test_loader.py
@@ -67,14 +67,14 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
 
     def test_schema_loader_source_errors(self):
         loader = ZConfig.loader.SchemaLoader()
-        self.assertRaisesRegexp(ZConfig.SchemaError,
-                                "illegal schema component name",
-                                loader.schemaComponentSource,
-                                '', None)
-        self.assertRaisesRegexp(ZConfig.SchemaError,
-                                "illegal schema component name",
-                                loader.schemaComponentSource,
-                                'foo..bar', None)
+        self.assertRaisesRegex(ZConfig.SchemaError,
+                               "illegal schema component name",
+                               loader.schemaComponentSource,
+                               '', None)
+        self.assertRaisesRegex(ZConfig.SchemaError,
+                               "illegal schema component name",
+                               loader.schemaComponentSource,
+                               'foo..bar', None)
 
     def test_config_loader_abstract_schema(self):
         class MockSchema(object):
@@ -84,10 +84,10 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
             def gettype(self, _t):
                 return self
 
-        self.assertRaisesRegexp(ZConfig.SchemaError,
-                                "abstract type",
-                                ZConfig.loader.ConfigLoader,
-                                MockSchema())
+        self.assertRaisesRegex(ZConfig.SchemaError,
+                               "abstract type",
+                               ZConfig.loader.ConfigLoader,
+                               MockSchema())
 
         s = MockSchema()
         s._abstract = False
@@ -95,10 +95,10 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
         loader = ZConfig.loader.ConfigLoader(s)
         s._abstract = True
 
-        self.assertRaisesRegexp(ZConfig.ConfigurationError,
-                                "cannot match abstract section",
-                                loader.startSection,
-                                None, None, None)
+        self.assertRaisesRegex(ZConfig.ConfigurationError,
+                               "cannot match abstract section",
+                               loader.startSection,
+                               None, None, None)
 
     def test_simple_import_using_prefix(self):
         self.load_schema_text("""\
@@ -387,7 +387,7 @@ class TestResourcesInZip(unittest.TestCase):
             ZConfig.loadConfigFile(schema, sio,
                                    overrides=["sample/data=othervalue"])
 
-class TestOpenPackageResource(unittest.TestCase):
+class TestOpenPackageResource(TestHelper, unittest.TestCase):
 
     magic_name = 'not a valid import name'
 
@@ -403,25 +403,18 @@ class TestOpenPackageResource(unittest.TestCase):
         self.__loader__ = MockLoader()
         self.__path__ = ['dir']
 
-        self.assertRaisesRegexp(ZConfig.SchemaResourceError,
-                                "error opening schema component",
-                                ZConfig.loader.openPackageResource,
-                                self.magic_name, 'a path')
+        self.assertRaisesRegex(ZConfig.SchemaResourceError,
+                               "error opening schema component",
+                               ZConfig.loader.openPackageResource,
+                               self.magic_name, 'a path')
 
         # Now with an empty path
         self.__path__ = []
-        self.assertRaisesRegexp(ZConfig.SchemaResourceError,
-                                "schema component not found",
-                                ZConfig.loader.openPackageResource,
-                                self.magic_name, 'a path')
+        self.assertRaisesRegex(ZConfig.SchemaResourceError,
+                               "schema component not found",
+                               ZConfig.loader.openPackageResource,
+                               self.magic_name, 'a path')
 
     def test_resource(self):
         r = ZConfig.loader.Resource(self, None)
         self.assertEqual(self.magic_name, r.magic_name)
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')

--- a/ZConfig/tests/test_matcher.py
+++ b/ZConfig/tests/test_matcher.py
@@ -21,6 +21,9 @@ from ZConfig.matcher import SectionValue
 from ZConfig.matcher import SectionMatcher
 from ZConfig.matcher import BaseMatcher
 
+from ZConfig.tests.support import TestHelper
+
+
 class SectionValueTestCase(unittest.TestCase):
 
     def test_repr(self):
@@ -46,7 +49,7 @@ class SectionValueTestCase(unittest.TestCase):
             'k                                       : v',
             str(sv))
 
-class SectionMatcherTestCase(unittest.TestCase):
+class SectionMatcherTestCase(TestHelper, unittest.TestCase):
 
     def test_constructor_error(self):
         class Mock(object):
@@ -54,12 +57,12 @@ class SectionMatcherTestCase(unittest.TestCase):
             def allowUnnamed(self):
                 return False
         mock = Mock()
-        self.assertRaisesRegexp(ConfigurationError,
-                                "sections may not be unnamed",
-                                SectionMatcher,
-                                mock, mock, None, None)
+        self.assertRaisesRegex(ConfigurationError,
+                               "sections may not be unnamed",
+                               SectionMatcher,
+                               mock, mock, None, None)
 
-class BaseMatcherTestCase(unittest.TestCase):
+class BaseMatcherTestCase(TestHelper, unittest.TestCase):
 
     def test_repr(self):
         class Mock(dict):
@@ -75,10 +78,10 @@ class BaseMatcherTestCase(unittest.TestCase):
         matcher = BaseMatcher(None, Mock(), None)
         matcher._sectionnames['foo'] = None
 
-        self.assertRaisesRegexp(ConfigurationError,
-                                "section names must not be re-used",
-                                matcher.addSection,
-                                None, 'foo', None)
+        self.assertRaisesRegex(ConfigurationError,
+                               "section names must not be re-used",
+                               matcher.addSection,
+                               None, 'foo', None)
 
     def test_construct_errors(self):
         class MockType(object):
@@ -133,15 +136,7 @@ class BaseMatcherTestCase(unittest.TestCase):
         t = MockType()
         t.sectiontype = MockType()
         matcher = BaseMatcher(None, t, None)
-        self.assertRaisesRegexp(ConfigurationError,
-                                'is not an allowed name',
-                                matcher.createChildMatcher,
-                                MockType(), 'ignored')
-
-
-
-def test_suite():
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+        self.assertRaisesRegex(ConfigurationError,
+                               'is not an allowed name',
+                               matcher.createChildMatcher,
+                               MockType(), 'ignored')

--- a/ZConfig/tests/test_schema.py
+++ b/ZConfig/tests/test_schema.py
@@ -1159,8 +1159,8 @@ class SchemaTestCase(TestHelper, unittest.TestCase):
         self.assertEqual(schema[0][1].example, 'This is an example')
 
     def checkErrorText(self, schema, error_text):
-        self.assertRaisesRegexp(ZConfig.SchemaError, error_text,
-                                self.load_schema_text, schema)
+        self.assertRaisesRegex(ZConfig.SchemaError, error_text,
+                               self.load_schema_text, schema)
 
     def test_error_bad_parent(self):
         self.checkErrorText(

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ options = dict(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,py37,pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
Fix the DeprecationWarnings it spewed, which is mostly `TestCase.assertRaisesRegexp`

Fixes #41 