### PR TITLE
support "delay" and "encoding" for <logfile>

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,13 @@
 Change History for ZConfig
 ==========================
 
-3.3.1 (unreleased)
+3.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The ``logfile`` section type defined by the ``ZConfig.components.logger``
+  package supports the optional ``delay`` and ``encoding`` parameters.
+  These can only be used for regular files, not the special ``STDOUT``
+  and ``STDERR`` streams.
 
 
 3.3.0 (2018-10-04)

--- a/ZConfig/components/logger/handlers.xml
+++ b/ZConfig/components/logger/handlers.xml
@@ -44,6 +44,26 @@
     <key name="format"
          default="------\n%(asctime)s %(levelname)s %(name)s %(message)s"
          datatype=".log_format"/>
+    <key name="encoding" required="no" datatype="string">
+      <description>
+        Encoding for the underlying file.
+
+        If not specified, Python's default encoding handling is used.
+
+        This cannot be specified for STDOUT or STDERR destinations, and
+        must be omitted in such cases.
+      </description>
+    </key>
+    <key name="delay" required="no" default="false" datatype="boolean">
+      <description>
+        If true, opening of the log file will be delayed until a message
+        is emitted.  This avoids creating logfiles that may only be
+        written to rarely or under special conditions.
+
+        This cannot be specified for STDOUT or STDERR destinations, and
+        must be omitted in such cases.
+      </description>
+    </key>
   </sectiontype>
 
   <sectiontype name="syslog"

--- a/ZConfig/components/logger/loghandler.py
+++ b/ZConfig/components/logger/loghandler.py
@@ -117,7 +117,7 @@ class Win32FileHandler(FileHandler):
         if self.delay:
             self.stream = None
         else:
-            self.stream = open(self.baseFilename, self.mode, self.encoding)
+            self.stream = self._open()
 
 
 if os.name == "nt":

--- a/ZConfig/components/logger/loghandler.py
+++ b/ZConfig/components/logger/loghandler.py
@@ -61,29 +61,26 @@ def _remove_from_reopenable(wr):
         pass
 
 
-class FileHandler(logging.StreamHandler):
+class FileHandler(logging.FileHandler):
     """File handler which supports reopening of logs.
 
     Re-opening should be used instead of the 'rollover' feature of
     the FileHandler from the standard library's logging package.
     """
 
-    def __init__(self, filename, mode="a"):
-        filename = os.path.abspath(filename)
-        logging.StreamHandler.__init__(self, open(filename, mode))
-        self.baseFilename = filename
-        self.mode = mode
+    def __init__(self, filename, mode="a", encoding=None, delay=False):
+        logging.FileHandler.__init__(self, filename,
+                                     mode=mode, encoding=encoding, delay=delay)
         self._wr = weakref.ref(self, _remove_from_reopenable)
         _reopenable_handlers.append(self._wr)
 
     def close(self):
-        self.stream.close()
         # This can raise a KeyError if the handler has already been
         # removed, but a later error can be raised if
         # StreamHandler.close() isn't called.  This seems the best
         # compromise.  :-(
         try:
-            logging.StreamHandler.close(self)
+            logging.FileHandler.close(self)
         except KeyError:  # pragma: no cover
             pass
         _remove_from_reopenable(self._wr)
@@ -91,8 +88,12 @@ class FileHandler(logging.StreamHandler):
     def reopen(self):
         self.acquire()
         try:
-            self.stream.close()
-            self.stream = open(self.baseFilename, self.mode)
+            if self.stream is not None:
+                self.stream.close()
+                if self.delay:
+                    self.stream = None
+                else:
+                    self.stream = self._open()
         finally:
             self.release()
 
@@ -113,7 +114,10 @@ class Win32FileHandler(FileHandler):
         except OSError:
             pass
 
-        self.stream = open(self.baseFilename, self.mode)
+        if self.delay:
+            self.stream = None
+        else:
+            self.stream = open(self.baseFilename, self.mode, self.encoding)
 
 
 if os.name == "nt":
@@ -152,14 +156,8 @@ class TimedRotatingFileHandler(logging.handlers.TimedRotatingFileHandler):
         self.doRollover()
 
 
-class NullHandler(logging.Handler):
+class NullHandler(logging.NullHandler):
     """Handler that does nothing."""
-
-    def emit(self, record):
-        pass
-
-    def handle(self, record):
-        pass
 
 
 class StartupHandler(logging.handlers.BufferingHandler):

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -170,6 +170,45 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
         logfile = logger.handlers[0]
         self.assertEqual(logfile.level, logging.DEBUG)
         self.assertTrue(isinstance(logfile, loghandler.FileHandler))
+        self.assertFalse(logfile.delay)
+        self.assertIsNotNone(logfile.stream)
+        logger.removeHandler(logfile)
+        logfile.close()
+
+    def test_with_encoded(self):
+        fn = self.mktemp()
+        logger = self.check_simple_logger("<eventlog>\n"
+                                          "  <logfile>\n"
+                                          "    path %s\n"
+                                          "    level debug\n"
+                                          "    encoding shift-jis\n"
+                                          "  </logfile>\n"
+                                          "</eventlog>" % fn)
+        logfile = logger.handlers[0]
+        self.assertEqual(logfile.level, logging.DEBUG)
+        self.assertTrue(isinstance(logfile, loghandler.FileHandler))
+        self.assertFalse(logfile.delay)
+        self.assertIsNotNone(logfile.stream)
+        self.assertEqual(logfile.stream.encoding, "shift-jis")
+        logger.removeHandler(logfile)
+        logfile.close()
+
+    def test_with_logfile_delayed(self):
+        fn = self.mktemp()
+        logger = self.check_simple_logger("<eventlog>\n"
+                                          "  <logfile>\n"
+                                          "    path %s\n"
+                                          "    level debug\n"
+                                          "    delay true\n"
+                                          "  </logfile>\n"
+                                          "</eventlog>" % fn)
+        logfile = logger.handlers[0]
+        self.assertEqual(logfile.level, logging.DEBUG)
+        self.assertTrue(isinstance(logfile, loghandler.FileHandler))
+        self.assertTrue(logfile.delay)
+        self.assertIsNone(logfile.stream)
+        logger.info("this is a test")
+        self.assertIsNotNone(logfile.stream)
         logger.removeHandler(logfile)
         logfile.close()
 
@@ -178,6 +217,18 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
 
     def test_with_stdout(self):
         self.check_standard_stream("stdout")
+
+    def test_delayed_stderr(self):
+        self.check_standard_stream_cannot_delay("stderr")
+
+    def test_delayed_stdout(self):
+        self.check_standard_stream_cannot_delay("stdout")
+
+    def test_encoded_stderr(self):
+        self.check_standard_stream_cannot_encode("stderr")
+
+    def test_encoded_stdout(self):
+        self.check_standard_stream_cannot_encode("stdout")
 
     def test_with_rotating_logfile(self):
         fn = self.mktemp()
@@ -295,6 +346,50 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
             setattr(sys, name, old_stream)
         logger.warning("woohoo!")
         self.assertTrue(sio.getvalue().find("woohoo!") >= 0)
+
+    def check_standard_stream_cannot_delay(self, name):
+        old_stream = getattr(sys, name)
+        conf = self.get_config("""
+            <eventlog>
+              <logfile>
+                level info
+                path %s
+                delay true
+              </logfile>
+            </eventlog>
+            """ % name.upper())
+        self.assertTrue(conf.eventlog is not None)
+        sio = StringIO()
+        setattr(sys, name, sio)
+        try:
+            with self.assertRaises(ValueError) as cm:
+                conf.eventlog()
+            self.assertIn("cannot delay opening %s" % name.upper(),
+                          str(cm.exception))
+        finally:
+            setattr(sys, name, old_stream)
+
+    def check_standard_stream_cannot_encode(self, name):
+        old_stream = getattr(sys, name)
+        conf = self.get_config("""
+            <eventlog>
+              <logfile>
+                level info
+                path %s
+                encoding utf-8
+              </logfile>
+            </eventlog>
+            """ % name.upper())
+        self.assertTrue(conf.eventlog is not None)
+        sio = StringIO()
+        setattr(sys, name, sio)
+        try:
+            with self.assertRaises(ValueError) as cm:
+                conf.eventlog()
+            self.assertIn("cannot specify encoding for %s" % name.upper(),
+                          str(cm.exception))
+        finally:
+            setattr(sys, name, old_stream)
 
     def test_custom_formatter(self):
         old_stream = sys.stdout
@@ -680,9 +775,43 @@ class TestReopeningLogfiles(TestReopeningRotatingLogfiles):
         h.release = lambda: calls.append("release")
 
         h.reopen()
-        h.close()
-
         self.assertEqual(calls, ["acquire", "release"])
+        del calls[:]
+
+        # FileHandler.close() does acquire/release, and invokes
+        # StreamHandler.flush(), which does the same. Since the lock is
+        # recursive, that's ok.
+        #
+        h.close()
+        self.assertEqual(calls, ["acquire", "acquire", "release", "release"])
+
+    def test_with_logfile_delayed_reopened(self):
+        fn = self.mktemp()
+        conf = self.get_config("<logger>\n"
+                               "  <logfile>\n"
+                               "    path %s\n"
+                               "    level debug\n"
+                               "    delay true\n"
+                               "    encoding shift-jis\n"
+                               "  </logfile>\n"
+                               "</logger>" % fn)
+        logger = conf.loggers[0]()
+        logfile = logger.handlers[0]
+        self.assertTrue(logfile.delay)
+        self.assertIsNone(logfile.stream)
+        logger.info("this is a test")
+        self.assertIsNotNone(logfile.stream)
+        self.assertEqual(logfile.stream.encoding, "shift-jis")
+
+        # After reopening, we expect the stream to be reset, to be
+        # opened at the next event to be logged:
+        logfile.reopen()
+        self.assertIsNone(logfile.stream)
+        logger.info("this is another test")
+        self.assertIsNotNone(logfile.stream)
+        self.assertEqual(logfile.stream.encoding, "shift-jis")
+        logger.removeHandler(logfile)
+        logfile.close()
 
 
 class TestFunctions(TestHelper, unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
 
 options = dict(
     name="ZConfig",
-    version='3.3.1.dev0',
+    version='3.4.0.dev0',
     author="Fred L. Drake, Jr.",
     author_email="fred@fdrake.net",
     maintainer="Zope Foundation and Contributors",


### PR DESCRIPTION
- neither parameter is supported for STDOUT, STDERR
  (errors are reported at the time the handler is
  constructed)

- closes #49