### PR TITLE
generate errors from bad <logfile> sections earlier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,11 @@ Change History for ZConfig
   These can only be used for regular files, not the special ``STDOUT``
   and ``STDERR`` streams.
 
-- More validation on the parameters to the ``logfile`` section is
-  performed early (at the construction of the factory, rather than at
-  creation of the ``logging`` handler).  This allows more checking of
-  parameter combinations before any log files are opened.
+- More validation on the parameters to the ``logfile`` and
+  ``email-notifier`` sections is performed early (at the construction of
+  the factory, rather than at creation of the ``logging`` handler).
+  This allows more checking of parameter combinations before any log
+  files are opened.
 
 
 3.3.0 (2018-10-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Change History for ZConfig
   These can only be used for regular files, not the special ``STDOUT``
   and ``STDERR`` streams.
 
+- More validation on the parameters to the ``logfile`` section is
+  performed early (at the construction of the factory, rather than at
+  creation of the ``logging`` handler).  This allows more checking of
+  parameter combinations before any log files are opened.
+
 
 3.3.0 (2018-10-04)
 ------------------

--- a/ZConfig/cfgparser.py
+++ b/ZConfig/cfgparser.py
@@ -122,8 +122,10 @@ class ZConfigParser(object):
             self.context.endSection(
                 prevsection, type_, name, section)
         except ZConfig.DataConversionError as e:
-            e.lineno = self.lineno
-            e.url = self.url
+            if e.lineno < 0:
+                e.lineno = self.lineno
+            if not e.url:
+                e.url = self.url
             raise
         except ZConfig.ConfigurationError as e:
             self.error(e.message)
@@ -141,8 +143,10 @@ class ZConfigParser(object):
         try:
             section.addValue(key, value, (self.lineno, None, self.url))
         except ZConfig.ConfigurationError as e:
-            e.lineno = self.lineno
-            e.url = self.url
+            if getattr(e, 'lineno', -1) < 0:
+                e.lineno = self.lineno
+            if not e.url:
+                e.url = self.url
             raise
 
     def handle_directive(self, section, rest):

--- a/ZConfig/cfgparser.py
+++ b/ZConfig/cfgparser.py
@@ -121,8 +121,12 @@ class ZConfigParser(object):
         try:
             self.context.endSection(
                 prevsection, type_, name, section)
+        except ZConfig.DataConversionError as e:
+            e.lineno = self.lineno
+            e.url = self.url
+            raise
         except ZConfig.ConfigurationError as e:
-            self.error(e.args[0])
+            self.error(e.message)
         return prevsection
 
     def handle_key_value(self, section, rest):
@@ -137,7 +141,9 @@ class ZConfigParser(object):
         try:
             section.addValue(key, value, (self.lineno, None, self.url))
         except ZConfig.ConfigurationError as e:
-            self.error(e.args[0])
+            e.lineno = self.lineno
+            e.url = self.url
+            raise
 
     def handle_directive(self, section, rest):
         m = _keyvalue_rx.match(rest)

--- a/ZConfig/components/logger/handlers.py
+++ b/ZConfig/components/logger/handlers.py
@@ -254,6 +254,15 @@ class HTTPHandlerFactory(HandlerFactory):
 
 class SMTPHandlerFactory(HandlerFactory):
 
+    def __init__(self, section):
+        HandlerFactory.__init__(self, section)
+        username = self.section.smtp_username
+        password = self.section.smtp_password
+        if (username or password) and not (username and password):
+            raise ValueError(
+                'Either both smtp-username and smtp-password or none must be '
+                'given')
+
     def create_loghandler(self):
         from ZConfig.components.logger import loghandler
         host, port = self.section.smtp_server
@@ -262,13 +271,9 @@ class SMTPHandlerFactory(HandlerFactory):
         else:
             mailhost = host, port
         kwargs = {}
-        if self.section.smtp_username and self.section.smtp_password:
+        if self.section.smtp_username:
             kwargs['credentials'] = (self.section.smtp_username,
                                      self.section.smtp_password)
-        elif (self.section.smtp_username or self.section.smtp_password):
-            raise ValueError(
-                'Either both smtp-username and smtp-password or none must be '
-                'given')
         return loghandler.SMTPHandler(mailhost,
                                       self.section.fromaddr,
                                       self.section.toaddrs,

--- a/ZConfig/components/logger/handlers.py
+++ b/ZConfig/components/logger/handlers.py
@@ -127,10 +127,16 @@ class FileHandlerFactory(HandlerFactory):
 
         if path == "STDERR":
             check_std_stream()
-            factory = functools.partial(loghandler.StreamHandler, sys.stderr)
+
+            def factory():
+                return loghandler.StreamHandler(sys.stderr)
+
         elif path == "STDOUT":
             check_std_stream()
-            factory = functools.partial(loghandler.StreamHandler, sys.stdout)
+
+            def factory():
+                return loghandler.StreamHandler(sys.stdout)
+
         elif when or max_bytes or old_files or interval:
             if not old_files:
                 raise ValueError("old-files must be set for log rotation")

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -326,25 +326,26 @@ class TestConfig(LoggingTestHelper, unittest.TestCase):
 
     def check_standard_stream(self, name):
         old_stream = getattr(sys, name)
+        conf = self.get_config("""
+            <eventlog>
+              <logfile>
+                level info
+                path %s
+              </logfile>
+            </eventlog>
+            """ % name.upper())
+        self.assertTrue(conf.eventlog is not None)
         # The factory has already been created; make sure it picks up
         # the stderr we set here when we create the logger and
         # handlers:
         sio = StringIO()
         setattr(sys, name, sio)
         try:
-            conf = self.get_config("""
-                <eventlog>
-                  <logfile>
-                    level info
-                    path %s
-                  </logfile>
-                </eventlog>
-                """ % name.upper())
-            self.assertTrue(conf.eventlog is not None)
             logger = conf.eventlog()
         finally:
             setattr(sys, name, old_stream)
         logger.warning("woohoo!")
+        self.assertIs(logger.handlers[0].stream, sio)
         self.assertTrue(sio.getvalue().find("woohoo!") >= 0)
 
     def check_standard_stream_cannot_delay(self, name):


### PR DESCRIPTION
- allow disallowed combinations of options be be identified
  and reported earlier (before any logfile handlers are created, and
  before any files are opened)

- ensure DataConversionError is not converted to
  ConfigurationSyntaxError when a section end is loaded