### PR TITLE
support styles for log formatters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,16 @@ Change History for ZConfig
 ------------------
 
 - The ``logfile`` section type defined by the ``ZConfig.components.logger``
+  package supports an optional ``style`` parameter.  This can be used to
+  configure alternate format styles as found in the Python 3 standard
+  library.  Four ``style`` values are supported: ``classic`` (the
+  default), ``format`` (equivalent to ``style='{'`` in Python 3),
+  ``template`` (equivalent to ``style='$'``), and ``safe-template``
+  (similar to ``template``, but using the ``string.Template`` method
+  ``safe_substitute`` method).  A best-effort implementation is provided
+  for Python 2.
+
+- The ``logfile`` section type defined by the ``ZConfig.components.logger``
   package supports the optional ``delay`` and ``encoding`` parameters.
   These can only be used for regular files, not the special ``STDOUT``
   and ``STDERR`` streams.

--- a/ZConfig/components/logger/handlers.xml
+++ b/ZConfig/components/logger/handlers.xml
@@ -1,4 +1,4 @@
-<component prefix="ZConfig.components.logger.handlers">
+<component prefix="ZConfig.components.logger">
   <description>
   </description>
 
@@ -12,8 +12,13 @@
     </description>
     <key name="formatter" datatype="dotted-name" required="no">
       <description>
-        Logging formatter class.  The default is :class:`logging.Formatter`.
-        An alternative is 'zope.exceptions.log.Formatter',
+        Logging formatter class.
+
+        The default is :class:`logging.Formatter` except for Python 2,
+        where a compatible formatter is used that supports the ``style``
+        option added in Python 3.
+
+        One alternative is 'zope.exceptions.log.Formatter',
         which enhances exception tracebacks with information from
         ``__traceback_info__`` and ``__traceback_supplement__``
         variables from each stack frame.
@@ -47,10 +52,20 @@
         Numeric values ``0`` through ``50`` (inclusive) are permitted.
       </description>
     </key>
+    <key name="style"
+         default="classic"
+         datatype=".formatter.log_format_style">
+      <description>
+        Replacement mechanism to use with the ``format`` string.
+
+        The value must be one of ``classic`` (the default), ``format``,
+        ``template``, or ``safe-template``.
+      </description>
+    </key>
   </sectiontype>
 
   <sectiontype name="logfile"
-               datatype=".FileHandlerFactory"
+               datatype=".handlers.FileHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
     <example><![CDATA[
@@ -108,7 +123,7 @@
     </key>
     <key name="format"
          default="------\n%(asctime)s %(levelname)s %(name)s %(message)s"
-         datatype=".log_format">
+         datatype=".formatter.escaped_string">
       <description>
         Format string for log entries.  This value is used to create an
         instance of the class identified by ``formatter``.
@@ -147,39 +162,40 @@
   </sectiontype>
 
   <sectiontype name="syslog"
-               datatype=".SyslogHandlerFactory"
+               datatype=".handlers.SyslogHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
-    <key name="facility" default="user" datatype=".syslog_facility"/>
+    <key name="facility" default="user" datatype=".handlers.syslog_facility"/>
     <key name="address" datatype="socket-address" default="localhost:514"/>
     <key name="format"
          default="%(name)s %(message)s"
-         datatype=".log_format"/>
+         datatype=".formatter.escaped_string"/>
   </sectiontype>
 
   <sectiontype name="win32-eventlog"
-               datatype=".Win32EventLogFactory"
+               datatype=".handlers.Win32EventLogFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
     <key name="appname" default="Zope"/>
     <key name="format"
          default="%(levelname)s %(name)s %(message)s"
-         datatype=".log_format"/>
+         datatype=".formatter.escaped_string"/>
   </sectiontype>
 
   <sectiontype name="http-logger"
-               datatype=".HTTPHandlerFactory"
+               datatype=".handlers.HTTPHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
-    <key name="url" default="http://localhost/" datatype=".http_handler_url"/>
-    <key name="method" default="GET" datatype=".get_or_post"/>
+    <key name="url" default="http://localhost/"
+         datatype=".handlers.http_handler_url"/>
+    <key name="method" default="GET" datatype=".handlers.get_or_post"/>
     <key name="format"
          default="%(asctime)s %(levelname)s %(name)s %(message)s"
-         datatype=".log_format"/>
+         datatype=".formatter.escaped_string"/>
   </sectiontype>
 
   <sectiontype name="email-notifier"
-               datatype=".SMTPHandlerFactory"
+               datatype=".handlers.SMTPHandlerFactory"
                implements="ZConfig.logger.handler"
                extends="ZConfig.logger.base-log-handler">
     <example><![CDATA[
@@ -211,7 +227,7 @@
     </key>
     <key name="format"
          default="%(asctime)s %(levelname)s %(name)s %(message)s"
-         datatype=".log_format">
+         datatype=".formatter.escaped_string">
       <description>
         Format string for the email content.
 

--- a/ZConfig/components/logger/tests/support.py
+++ b/ZConfig/components/logger/tests/support.py
@@ -1,0 +1,88 @@
+##############################################################################
+#
+# Copyright (c) 2002, 2018 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""\
+Test support for ZConfig.components.logger.
+
+"""
+
+import logging
+import os
+import tempfile
+
+from ZConfig.components.logger import loghandler
+import ZConfig._compat
+import ZConfig
+import ZConfig.tests.support
+
+
+class LoggingTestHelper(ZConfig.tests.support.TestHelper):
+
+    # Not derived from unittest.TestCase; some test runners seem to
+    # think that means this class contains tests.
+
+    # XXX This tries to save and restore the state of logging around
+    # the test.  Somewhat surgical; there may be a better way.
+
+    def setUp(self):
+        self._created = []
+        self._old_logger = logging.getLogger()
+        self._old_level = self._old_logger.level
+        self._old_handlers = self._old_logger.handlers[:]
+        self._old_logger.handlers[:] = []
+        self._old_logger.setLevel(logging.WARN)
+
+        self._old_logger_dict = logging.root.manager.loggerDict.copy()
+        logging.root.manager.loggerDict.clear()
+
+    def tearDown(self):
+        logging.root.manager.loggerDict.clear()
+        logging.root.manager.loggerDict.update(self._old_logger_dict)
+
+        for h in self._old_logger.handlers:
+            self._old_logger.removeHandler(h)
+        for h in self._old_handlers:
+            self._old_logger.addHandler(h)  # pragma: no cover
+        self._old_logger.setLevel(self._old_level)
+
+        while self._created:
+            os.unlink(self._created.pop())
+
+        self.assertEqual(loghandler._reopenable_handlers, [])
+        loghandler.closeFiles()
+        loghandler._reopenable_handlers == []
+
+    def mktemp(self):
+        fd, fn = tempfile.mkstemp()
+        os.close(fd)
+        self._created.append(fn)
+        return fn
+
+    def move(self, fn):
+        nfn = self.mktemp()
+        os.rename(fn, nfn)
+        return nfn
+
+    _schema = None
+
+    def get_schema(self):
+        if self._schema is None:
+            sio = ZConfig._compat.NStringIO(self._schematext)
+            self.__class__._schema = ZConfig.loadSchemaFile(sio)
+        return self._schema
+
+    def get_config(self, text):
+        conf, handler = ZConfig.loadConfigFile(self.get_schema(),
+                                               ZConfig._compat.NStringIO(text))
+        self.assertTrue(not handler)
+        return conf

--- a/ZConfig/components/logger/tests/test_formatter.py
+++ b/ZConfig/components/logger/tests/test_formatter.py
@@ -1,0 +1,447 @@
+# coding=utf-8
+##############################################################################
+#
+# Copyright (c) 2018 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""\
+Tests for ZConfig.components.logger.formatter.
+
+"""
+
+import logging
+import sys
+import unittest
+
+import ZConfig.components.logger.formatter
+import ZConfig.components.logger.tests.support
+
+
+class LogFormatStyleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.convert = ZConfig.components.logger.formatter.log_format_style
+
+    def test_classic(self):
+        self.assertEqual(self.convert('classic'), 'classic')
+        self.assertEqual(self.convert('Classic'), 'classic')
+        self.assertEqual(self.convert('CLASSIC'), 'classic')
+        self.assertEqual(self.convert('cLaSsIc'), 'classic')
+
+    def test_format(self):
+        self.assertEqual(self.convert('format'), 'format')
+        self.assertEqual(self.convert('Format'), 'format')
+        self.assertEqual(self.convert('FORMAT'), 'format')
+        self.assertEqual(self.convert('fOrMaT'), 'format')
+
+    def test_template(self):
+        self.assertEqual(self.convert('template'), 'template')
+        self.assertEqual(self.convert('Template'), 'template')
+        self.assertEqual(self.convert('TEMPLATE'), 'template')
+        self.assertEqual(self.convert('tEmPlAtE'), 'template')
+
+    def test_safe_template(self):
+        self.assertEqual(self.convert('safe-template'), 'safe-template')
+        self.assertEqual(self.convert('Safe-Template'), 'safe-template')
+        self.assertEqual(self.convert('SAFE-TEMPLATE'), 'safe-template')
+        self.assertEqual(self.convert('sAfE-tEmPlAtE'), 'safe-template')
+
+    def test_bad_values(self):
+
+        def check(value):
+            with self.assertRaises(ValueError) as cm:
+                self.convert(value)
+            self.assertIn('log_format_style must be one of',
+                          str(cm.exception))
+            self.assertIn('found %r' % value, str(cm.exception))
+
+        check('')
+        check('just-some-junk')
+        check('Another Pile of Junk')
+        check('%')
+        check('{')
+        check('$')
+
+
+class StyledFormatterTestHelper(
+        ZConfig.components.logger.tests.support.LoggingTestHelper):
+
+    _schematext = """
+      <schema>
+        <import package='ZConfig.components.logger'/>
+        <section type='eventlog' name='*' attribute='eventlog'/>
+      </schema>
+    """
+
+    def setUp(self):
+        ZConfig.components.logger.tests.support.LoggingTestHelper.setUp(self)
+        self.record = logging.LogRecord(
+            'ZConfig.foo.bar', logging.WARN, __file__, 42,
+            'my message, %r %r', ('with', 'some args'), None, 'faux_func')
+        self.record.x1 = 24
+        self.record.x2 = 37
+
+    def get_logger_factory(self, style=None, format=None):
+        formatter_lines = []
+        if style:
+            formatter_lines.append('style %s' % style)
+        if format:
+            formatter_lines.append('format %s' % format)
+        formatter_config = '\n    '.join(formatter_lines)
+        parsed = self.get_config(self._config_template % formatter_config)
+        return parsed.eventlog
+
+    def get_formatter_factory(self, style=None, format=None):
+        logger_factory = self.get_logger_factory(style=style, format=format)
+        return logger_factory.handler_factories[0].create_formatter
+
+
+class LoggerStyledFormatterTestCase(StyledFormatterTestHelper,
+                                    unittest.TestCase):
+
+    _config_template = """\
+      <eventlog>
+        <logfile>
+          path STDOUT
+          level debug
+          %s
+        </logfile>
+      </eventlog>
+    """
+
+    def test_classic_explicit(self):
+        factory = self.get_formatter_factory(
+            style='classic',
+            format='%(levelname)s %(levelno)s %(message)s')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(content, "WARNING 30 my message, 'with' 'some args'")
+
+    def test_classic_implicit(self):
+        factory = self.get_formatter_factory(
+            format='%(levelname)s %(levelno)s %(message)s')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(content, "WARNING 30 my message, 'with' 'some args'")
+
+    def test_format(self):
+        #
+        # The last item here isn't a format string placeholder; it
+        # almost looks like a classic format operation, but would cause
+        # an error.  We're just expecting it to show up in the result as
+        # a literal.
+        #
+        # It would not be allowed in older versions of ZConfig, or for
+        # classic style.
+        #
+        factory = self.get_formatter_factory(
+            style='format',
+            format='{levelname} {levelno} {message} %(stuff)')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, "WARNING 30 my message, 'with' 'some args' %(stuff)")
+
+    def test_format_with_anonymous_placeholders(self):
+        with self.assertRaises(ValueError):
+            self.get_formatter_factory(
+                style='format',
+                format='{} {} {} %(stuff)')
+
+    def test_format_with_positional_placeholders(self):
+        with self.assertRaises(ValueError):
+            self.get_formatter_factory(
+                style='format',
+                format='{1} {2} {3} %(stuff)')
+
+    # These comments apply to the test_template_* and
+    # test_safe_template_* tests that demonstrate successful formatter
+    # creations.
+    #
+    # The last item here isn't a format string placeholder; it almost
+    # looks like a classic format operation, but would cause an error.
+    # We're just expecting it to show up in the result as a literal.
+    #
+    # It would not be allowed in older versions of ZConfig, or for
+    # classic style.
+    #
+    # Note the $ must be doubled to get through the ZConfig syntax for
+    # substitutions.
+    #
+    def test_template_with_braces(self):
+        #
+        factory = self.get_formatter_factory(
+            style='template',
+            format='$${levelname} $${levelno} $${message} %(stuff) {extra}')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, ("WARNING 30 my message, 'with' 'some args'"
+                      " %(stuff) {extra}"))
+
+    def test_template_without_braces(self):
+        factory = self.get_formatter_factory(
+            style='template',
+            format='$$levelname $$levelno $$message %(stuff) {extra}')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, ("WARNING 30 my message, 'with' 'some args'"
+                      " %(stuff) {extra}"))
+
+    def test_template_with_junk(self):
+        #
+        # There's a lot of junk in this format; we're verifying that
+        # it's caught when constructing the factory.
+        #
+        with self.assertRaises(ValueError):
+            self.get_formatter_factory(
+                style='format',
+                format='$$} $${levelno')
+
+    def test_safe_template_with_braces(self):
+        factory = self.get_formatter_factory(
+            style='safe-template',
+            format='$${levelname} $${levelno} $${message} %(stuff) {extra}')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, ("WARNING 30 my message, 'with' 'some args'"
+                      " %(stuff) {extra}"))
+
+    def test_safe_template_without_braces(self):
+        factory = self.get_formatter_factory(
+            style='safe-template',
+            format='$$levelname $$levelno $$message %(stuff) {extra}')
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, ("WARNING 30 my message, 'with' 'some args'"
+                      " %(stuff) {extra}"))
+
+    def test_safe_template_with_junk(self):
+        factory = self.get_formatter_factory(
+            style='safe-template',
+            format=('$${levelname} $${levelno} $${message} %(stuff) {extra}'
+                    ' $$} $${levelno  $${bad-mojo}'))
+        formatter = factory()
+        content = formatter.format(self.record)
+        self.assertEqual(
+            content, ("WARNING 30 my message, 'with' 'some args'"
+                      " %(stuff) {extra} $} ${levelno  ${bad-mojo}"))
+
+
+class ZopeExceptionsFormatterTestCase(LoggerStyledFormatterTestCase):
+
+    # We test against the zope.exceptions formatter since it's a common
+    # example of a formatter that inherits almost everything, but
+    # defines it's own formatException.  For Python 2, we want to be
+    # sure the extended formatException is used.
+
+    _config_template = """\
+      <eventlog>
+        <logfile>
+          path STDOUT
+          level debug
+          formatter zope.exceptions.log.Formatter
+          %s
+        </logfile>
+      </eventlog>
+    """
+
+    def test_format_with_traceback_info(self):
+        factory = self.get_formatter_factory(
+            style='format',
+            format='{levelname} {levelno} {message}')
+        formatter = factory()
+
+        def fail():
+            raise RuntimeError('foo')
+
+        def something():
+            __traceback_info__ = 42
+            fail()
+
+        try:
+            something()
+        except RuntimeError:
+            self.record.exc_info = sys.exc_info()
+
+        content = formatter.format(self.record)
+        self.assertIn(' - __traceback_info__: 42', content)
+        self.assertIn("WARNING 30 my message, 'with' 'some args'", content)
+
+
+class CustomFormatterClassWithoutStyleParamTestCase(
+        LoggerStyledFormatterTestCase):
+
+    _config_template = """\
+      <eventlog>
+        <logfile>
+          path STDOUT
+          level debug
+          formatter %s.StylelessFormatter
+          %%s
+        </logfile>
+      </eventlog>
+    """ % __name__
+
+
+class CustomFormatterFactoryWithoutStyleParamTestCase(
+        LoggerStyledFormatterTestCase):
+
+    _config_template = """\
+      <eventlog>
+        <logfile>
+          path STDOUT
+          level debug
+          formatter %s.styleless_formatter
+          %%s
+        </logfile>
+      </eventlog>
+    """ % __name__
+
+
+class StylelessFormatter(logging.Formatter):
+
+    def __init__(self, fmt=None, datefmt=None):
+        logging.Formatter.__init__(self, fmt=fmt, datefmt=datefmt)
+
+
+def styleless_formatter(fmt=None, datefmt=None):
+    return StylelessFormatter(fmt=fmt, datefmt=datefmt)
+
+
+class UnstylableFormatter(StylelessFormatter):
+
+    # Really only declared unstylable on Python 2; Python 3 formatters
+    # are assumed to be cooperative w/r/t format invoking formatMessage.
+
+    def format(self, record):
+        return 'No playing nice!'
+
+
+class UnstylableFormatterTestCase(StyledFormatterTestHelper,
+                                  unittest.TestCase):
+
+    _config_template = """\
+      <eventlog>
+        <logfile>
+          path STDOUT
+          level debug
+          formatter %s.UnstylableFormatter
+          %%s
+        </logfile>
+      </eventlog>
+    """ % __name__
+
+    @unittest.skipIf(sys.version_info[0] > 2,
+                     'Only applies for Python 2.')
+    def test_py2_unstylable(self):
+        factory = self.get_formatter_factory(
+            style='template',
+            format='$${levelname} $${levelno} $${message}')
+        with self.assertRaises(ValueError) as cm:
+            factory()
+        self.assertIn('cannot inject non-classic formatting into formatter',
+                      str(cm.exception))
+
+
+class Py2EncodingTestCase(StyledFormatterTestHelper,
+                          unittest.TestCase):
+
+    text = u'\u6d4b\u8bd5'  # u'测试'
+    encoded_text = text.encode('utf-8')
+
+    @unittest.skipIf(sys.version_info[0] > 2,
+                     'Only applies for Python 2.')
+    def test_format_message_with_unhandlable_unicode_decoding_error(self):
+        # Triggering outer exception handler in Py2Formatter.formatMessage.
+        formatter = ZConfig.components.logger.formatter.Py2Formatter(
+            '%(name)s %(message)s ' + self.encoded_text)
+        self.record.message = u'simple text'
+
+        # Because the decoding error is caused by the unicode message,
+        # decoding the nsame of the logger doesn't help:
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            formatter.formatMessage(self.record)
+
+        emsg = str(cm.exception)
+        self.assertIn("'ascii' codec can't decode byte", emsg)
+        self.assertIn('ordinal not in range(128)', emsg)
+
+    @unittest.skipIf(sys.version_info[0] > 2,
+                     'Only applies for Python 2.')
+    def _test_format_message_with_unicode_logger_name(self):
+        # https://bugs.python.org/issue25664
+        logname = __name__ + '.' + self.encoded_text
+        assert isinstance(logname, bytes)
+        self.record.name = logname
+        formatter = ZConfig.components.logger.formatter.Py2Formatter(
+            '%(name)s %(message)s')
+        self.record.message = self.record.getMessage()
+
+        msg = formatter.formatMessage(self.record)
+
+        self.assertIsInstance(msg, bytes)
+        self.assertEqual(msg, logname + b" my message, 'with' 'some args'")
+
+    @unittest.skipIf(sys.version_info[0] > 2,
+                     'Only applies for Python 2.')
+    def test_format_with_unicode_traceback_content(self):
+        try:
+            raise RuntimeError('we made this up')
+        except RuntimeError:
+            self.record.exc_info = sys.exc_info()
+        formatter = ZConfig.components.logger.formatter.Py2Formatter(
+            '%(name)s %(message)s')
+        # For formatMessage to return unicode:
+        self.record.msg += u''
+        formatter.format(self.record)
+        assert isinstance(self.record.exc_text, bytes)
+        assert isinstance(formatter.formatMessage(self.record), unicode)  # NOQA
+        # We're now certain self.record.exc_text has been properly formatted.
+        # Convert to unicode and add some interesting bits.
+        encoded_text = self.text.encode(sys.getfilesystemencoding())
+        self.record.exc_text = (self.record.exc_text + encoded_text)
+        self.record.message = self.record.message.decode('utf-8')
+
+        msg = formatter.format(self.record)
+
+        self.assertIsInstance(msg, unicode)  # NOQA
+
+    @unittest.skipIf(sys.version_info[0] > 2,
+                     'Only applies for Python 2.')
+    def test_format_with_unicode_traceback_content_trailing_msg_newline(self):
+        # The point of this is to cover the case of *not* adding a
+        # newline to the message before appending the formatted
+        # traceback.
+        try:
+            raise RuntimeError('we made this up')
+        except RuntimeError:
+            self.record.exc_info = sys.exc_info()
+        formatter = ZConfig.components.logger.formatter.Py2Formatter(
+            '%(name)s %(message)s')
+        # For formatMessage to return unicode:
+        self.record.msg += u'\n'
+        formatter.format(self.record)
+        assert isinstance(self.record.exc_text, bytes)
+        assert isinstance(formatter.formatMessage(self.record), unicode)  # NOQA
+        # We're now certain self.record.exc_text has been properly formatted.
+        # Convert to unicode and add some interesting bits.
+        encoded_text = self.text.encode(sys.getfilesystemencoding())
+        self.record.exc_text = (self.record.exc_text + encoded_text)
+        self.record.message = self.record.message.decode('utf-8')
+
+        msg = formatter.format(self.record)
+
+        self.assertIsInstance(msg, unicode)  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open("CHANGES.rst") as f:
 tests_require = [
     'docutils',
     'manuel',
+    'zope.exceptions',
     'zope.testrunner',
 ]
 


### PR DESCRIPTION
- pull in python3 style implementations; extend with '$' variant using
  safe_substitute instead of substitute

- add default python2 formatter that provides style support

- push validation of format string into handler (formatter)
  construction, since validation can no longer be performed only on the
  basis of the format value

- deal with 3rd-party formatter factories by clobbering the
  formatMessage and usesTime methods based on the selected style when
  not "classic"; for python2 we also take over the format method, else
  our formatMessage would not be used

- refactor: move formatter validation & construction to new
  ZConfig.components.logger.formatter module

closes issue #46