### PR TITLE
correct types for log record sample values

### DIFF
--- a/ZConfig/components/logger/formatter.py
+++ b/ZConfig/components/logger/formatter.py
@@ -91,7 +91,7 @@ _log_format_styles = {
 
 _log_format_variables = {
     'name': __name__,
-    'levelno': '3',
+    'levelno': 3,
     'levelname': 'DEBUG',
     'pathname': 'apath',
     'filename': 'afile',
@@ -99,8 +99,8 @@ _log_format_variables = {
     'lineno': 1,
     'created': 1.1,
     'asctime': 'atime',
-    'msecs': 1,
-    'relativeCreated': 1,
+    'msecs': 1.1,
+    'relativeCreated': 1.1,
     'thread': 1,
     'message': 'amessage',
     'process': 1,

--- a/ZConfig/components/logger/handlers.py
+++ b/ZConfig/components/logger/handlers.py
@@ -23,22 +23,8 @@ from ZConfig.components.logger.factory import Factory
 import ZConfig.components.logger.formatter
 
 
-_log_format_variables = {
-    'name': '',
-    'levelno': '3',
-    'levelname': 'DEBUG',
-    'pathname': 'apath',
-    'filename': 'afile',
-    'module': 'amodule',
-    'lineno': 1,
-    'created': 1.1,
-    'asctime': 'atime',
-    'msecs': 1,
-    'relativeCreated': 1,
-    'thread': 1,
-    'message': 'amessage',
-    'process': 1,
-    }
+_log_format_variables = (
+    ZConfig.components.logger.formatter._log_format_variables)
 
 
 def log_format(value):


### PR DESCRIPTION
using a string instead of an integer for levelno causes some
reasonable formats to trigger validation failures when they
should not

fixes issue #61