### PR TITLE
update log_format to accept "funcName"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Many changes have been made in the support for logging configurations:
   This allows more checking of parameter combinations before any log
   files are opened.
 
+- The ``ZConfig.components.logger.handlers.log_format`` data type
+  function now supports formats that include numeric formatting for
+  ``levelno``, and accept ``funcName`` as a valid log record field
+  (added in Python 2.6 and 3.1).
+
 
 3.3.0 (2018-10-04)
 ------------------

--- a/ZConfig/components/logger/formatter.py
+++ b/ZConfig/components/logger/formatter.py
@@ -122,6 +122,7 @@ _log_format_variables = {
     'thread': 1,
     'message': 'amessage',
     'process': 1,
+    'funcName': 'fname',
     }
 
 

--- a/ZConfig/components/logger/tests/test_formatter.py
+++ b/ZConfig/components/logger/tests/test_formatter.py
@@ -449,6 +449,27 @@ class Py2EncodingTestCase(StyledFormatterTestHelper,
 
 class FieldTypesTestCase(StyledFormatterTestHelper, unittest.TestCase):
 
+    def test_func_name_classic(self):
+        formatter = self.get_formatter(
+            style='classic',
+            format='%(levelname)s %(levelno)2d %(funcName)s')
+        output = formatter.format(self.record)
+        self.assertIn('WARNING 30 faux_func', output)
+
+    def test_func_name_format(self):
+        formatter = self.get_formatter(
+            style='format',
+            format='{levelname} {levelno:02d} {funcName}')
+        output = formatter.format(self.record)
+        self.assertIn('WARNING 30 faux_func', output)
+
+    def test_func_name_template(self):
+        formatter = self.get_formatter(
+            style='template',
+            format='$$levelname $$levelno $$funcName')
+        output = formatter.format(self.record)
+        self.assertIn('WARNING 30 faux_func', output)
+
     def test_levelno_integer_classic(self):
         formatter = self.get_formatter(
             style='classic',

--- a/ZConfig/components/logger/tests/test_logger.py
+++ b/ZConfig/components/logger/tests/test_logger.py
@@ -777,6 +777,22 @@ class TestFunctions(ZConfig.tests.support.TestHelper, unittest.TestCase):
         fmt = handlers.log_format(r'\n\t\b\f\r')
         self.assertEqual(fmt, '\n\t\b\f\r')
 
+    def test_log_format_func_name(self):
+        fmt = '%(funcName)s'
+        self.assertEqual(handlers.log_format(fmt), fmt)
+
+    def test_log_format_levelno_integer(self):
+        fmt = '%(levelno)2d'
+        self.assertEqual(handlers.log_format(fmt), fmt)
+
+    def test_log_format_msecs_float(self):
+        fmt = '%(msecs)03.0f'
+        self.assertEqual(handlers.log_format(fmt), fmt)
+
+    def test_log_format_relative_created_float(self):
+        fmt = '%(relativeCreated)+.3f'
+        self.assertEqual(handlers.log_format(fmt), fmt)
+
     def test_resolve_deep(self):
         old_mod = None
         if hasattr(logging, 'handlers'):


### PR DESCRIPTION
- field added to log records in Python 2.6 and 3.1,
  so accepted for all python versions supported by
  ZConfig

- added tests specifically for the log_format function
  accepting "funcName" and numeric formatting for
  other fields recently touched in ZConfig

partially addresses issue #63