### PR TITLE
update to tolerate logging.Formatter validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8-dev
     - pypy
     - pypy3
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 3.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added support for Python 3.8.  This primarily involves avoiding the
+  new-in-3.8 validation of the format string when using the
+  'safe-template' format style, since that's not supported in the Python
+  standard library.
 
 
 3.5.0 (2019-06-24)

--- a/ZConfig/components/logger/formatter.py
+++ b/ZConfig/components/logger/formatter.py
@@ -250,7 +250,7 @@ class FormatterFactory(object):
                 # non-standard, so we reach under the covers a bit.
                 #
                 # Python 3.8 adds a validate option, defaulting to True,
-                # which cases the format string to be checked.  Since
+                # which causes the format string to be checked.  Since
                 # safe-template is not a standard style, we want to
                 # suppress this.
                 #

--- a/ZConfig/components/logger/formatter.py
+++ b/ZConfig/components/logger/formatter.py
@@ -248,8 +248,17 @@ class FormatterFactory(object):
             else:
                 # A formatter class that supports style, but our style is
                 # non-standard, so we reach under the covers a bit.
+                #
+                # Python 3.8 adds a validate option, defaulting to True,
+                # which cases the format string to be checked.  Since
+                # safe-template is not a standard style, we want to
+                # suppress this.
+                #
+                kwargs = dict()
+                if sys.version_info >= (3, 8):
+                    kwargs['validate'] = False
                 formatter = self.factory(self.format, self.dateformat,
-                                         style='$')
+                                         style='$', **kwargs)
                 assert formatter._style._fmt == self.format
                 formatter._style = stylist
         else:

--- a/ZConfig/components/logger/tests/test_formatter.py
+++ b/ZConfig/components/logger/tests/test_formatter.py
@@ -25,6 +25,17 @@ import ZConfig.components.logger.formatter
 import ZConfig.components.logger.tests.support
 
 
+# In Python 3.8, a KeyError raised by string interpolation is re-written
+# into a ValueError reporting a reference to an undefined field.  We're
+# not masking the exception, but we want to check for the right one in
+# the tests below (without catching anything else).
+#
+if sys.version_info >= (3, 8):
+    MissingFieldError = ValueError
+else:
+    MissingFieldError = KeyError
+
+
 class LogFormatStyleTestCase(unittest.TestCase):
 
     def setUp(self):
@@ -314,7 +325,10 @@ class CustomFormatterFactoryWithoutStyleParamTestCase(
 class StylelessFormatter(logging.Formatter):
 
     def __init__(self, fmt=None, datefmt=None):
-        logging.Formatter.__init__(self, fmt=fmt, datefmt=datefmt)
+        kwargs = dict()
+        if sys.version_info >= (3, 8):
+            kwargs['validate'] = False
+        logging.Formatter.__init__(self, fmt=fmt, datefmt=datefmt, **kwargs)
 
 
 def styleless_formatter(fmt=None, datefmt=None):
@@ -552,9 +566,9 @@ class ArbitraryFieldsTestCase(StyledFormatterTestHelper, unittest.TestCase):
             arbitrary_fields=True)
 
         # The formatter still breaks when it references an undefined field:
-        with self.assertRaises(KeyError) as cm:
+        with self.assertRaises(MissingFieldError) as cm:
             formatter.format(self.record)
-        self.assertEqual(str(cm.exception), "'undefined_field'")
+        self.assertIn("'undefined_field'", str(cm.exception))
 
     def test_classic_arbitrary_field_present(self):
         formatter = self.get_formatter(
@@ -574,9 +588,9 @@ class ArbitraryFieldsTestCase(StyledFormatterTestHelper, unittest.TestCase):
             arbitrary_fields=True)
 
         # The formatter still breaks when it references an undefined field:
-        with self.assertRaises(KeyError) as cm:
+        with self.assertRaises(MissingFieldError) as cm:
             formatter.format(self.record)
-        self.assertEqual(str(cm.exception), "'undefined_field'")
+        self.assertIn("'undefined_field'", str(cm.exception))
 
     def test_format_arbitrary_field_present(self):
         formatter = self.get_formatter(
@@ -596,9 +610,9 @@ class ArbitraryFieldsTestCase(StyledFormatterTestHelper, unittest.TestCase):
             arbitrary_fields=True)
 
         # The formatter still breaks when it references an undefined field:
-        with self.assertRaises(KeyError) as cm:
+        with self.assertRaises(MissingFieldError) as cm:
             formatter.format(self.record)
-        self.assertEqual(str(cm.exception), "'undefined_field'")
+        self.assertIn("'undefined_field'", str(cm.exception))
 
     def test_template_arbitrary_field_present(self):
         formatter = self.get_formatter(

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ options = dict(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy,coverage-report
+envlist = py27,py34,py35,py36,py37,py38,pypy,coverage-report
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
- required to work with Python 3.8
- fixes #69