### PR TITLE
Fix issues with Python 3.2 ResourceWarning workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu
+        - ["ubuntu", "ubuntu-20.04"]
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -34,7 +34,7 @@ jobs:
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["pypy-2.7", "pypy"]
         - ["pypy-3.7", "pypy3"]
         - ["3.9",   "docs"]
@@ -37,13 +38,13 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "d8ee00613a60c98a8d2227b0564403d0e447741a"
+commit-id = "180c99ed3def7da6e173a5a496cad6484eadd044"
 
 [python]
 with-windows = false

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "b4cfc9ca6065ca82646fa69d04ee4c15c58035e1"
+commit-id = "d8ee00613a60c98a8d2227b0564403d0e447741a"
 
 [python]
 with-windows = false
@@ -11,6 +11,7 @@ with-future-python = false
 with-legacy-python = true
 with-docs = true
 with-sphinx-doctests = false
+with-macos = false
 
 [tox]
 use-flake8 = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 3.6.1 (unreleased)
 ==================
 
+- Add support for Python 3.11.
+
 - Drop support for Python 3.4.
 
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ options = dict(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/src/ZConfig/components/logger/tests/test_logger.py
+++ b/src/ZConfig/components/logger/tests/test_logger.py
@@ -352,7 +352,7 @@ class TestConfig(ZConfig.components.logger.tests.support.LoggingTestHelper,
         syslog.close()  # avoid ResourceWarning
         try:
             syslog.socket.close()  # ResourceWarning under 3.2
-        except socket.SocketError:  # pragma: no cover
+        except socket.error:  # pragma: no cover
             pass
 
     def test_with_http_logger_localhost(self):

--- a/src/ZConfig/components/logger/tests/test_logger.py
+++ b/src/ZConfig/components/logger/tests/test_logger.py
@@ -339,7 +339,6 @@ class TestConfig(ZConfig.components.logger.tests.support.LoggingTestHelper,
         self.assertTrue(sio.getvalue().find("Don't panic") >= 0)
 
     def test_with_syslog(self):
-        import socket
         logger = self.check_simple_logger("<eventlog>\n"
                                           "  <syslog>\n"
                                           "    level error\n"

--- a/src/ZConfig/components/logger/tests/test_logger.py
+++ b/src/ZConfig/components/logger/tests/test_logger.py
@@ -350,10 +350,6 @@ class TestConfig(ZConfig.components.logger.tests.support.LoggingTestHelper,
         self.assertEqual(syslog.level, logging.ERROR)
         self.assertTrue(isinstance(syslog, loghandler.SysLogHandler))
         syslog.close()  # avoid ResourceWarning
-        try:
-            syslog.socket.close()  # ResourceWarning under 3.2
-        except socket.error:  # pragma: no cover
-            pass
 
     def test_with_http_logger_localhost(self):
         logger = self.check_simple_logger("<eventlog>\n"

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy
     pypy3
     docs
@@ -66,8 +67,8 @@ deps =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
-    coverage html
-    coverage report -m --fail-under=95
+    coverage html --ignore-errors
+    coverage report --ignore-errors --show-missing --fail-under=95
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
It doesn’t seem that `socket.SocketError` has existed in the standard library in vaguely-recent memory. This causes an error like the following:

```
AttributeError: module 'socket' has no attribute 'SocketError'
```

It seems that `socket.error` was intended instead.

Furthermore, `syslog.socket` will be `None` here on Python 3.11, which causes another unhandled exception:

```
AttributeError: 'NoneType' object has no attribute 'close'
```

Since the whole workaround is supposed to be for Python 3.2, which is long since end-of-life, the best approach seems to be to remove the workaround entirely.