### PR TITLE
Fix tests for Python 3.12

### DIFF
--- a/src/ZConfig/tests/support.py
+++ b/src/ZConfig/tests/support.py
@@ -17,7 +17,6 @@
 import contextlib
 import os
 import sys
-import unittest
 from io import StringIO
 from urllib.request import pathname2url
 
@@ -78,12 +77,6 @@ def with_stdin_from_input_file(fname):
 
 class TestHelper:
     """Utility methods which can be used with the schema support."""
-
-    # Not derived from unittest.TestCase; some test runners seem to
-    # think that means this class contains tests.
-
-    assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegex',
-                                unittest.TestCase.assertRaisesRegexp)
 
     def load_both(self, schema_url, conf_url):
         schema = self.load_schema(schema_url)


### PR DESCRIPTION
In the tests, replace the assertRaisesRegexp method, deprecated since Python 3.2, with assertRaisesRegex to prevent test failures following the method's removal in Python 3.12.

---

This fixes test fail issues with py3.12. They fail with similar error:
```
======================================================================
ERROR: test_cfgimports (unittest.loader._FailedTest.test_cfgimports)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_cfgimports
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/loader.py", line 382, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/loader.py", line 325, in _get_module_from_name
    __import__(name)
  File "/var/tmp/portage/dev-python/zconfig-4.0/work/ZConfig-4.0/src/ZConfig/tests/test_cfgimports.py", line 21, in <module>
    import ZConfig.tests.support
  File "/var/tmp/portage/dev-python/zconfig-4.0/work/ZConfig-4.0-python3_12/install/usr/lib/python3.12/site-packages/ZConfig/tests/support.py", line 79, in <module>
    class TestHelper:
  File "/var/tmp/portage/dev-python/zconfig-4.0/work/ZConfig-4.0-python3_12/install/usr/lib/python3.12/site-packages/ZConfig/tests/support.py", line 86, in TestHelper
    unittest.TestCase.assertRaisesRegexp)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'TestCase' has no attribute 'assertRaisesRegexp'. Did you mean: 'assertRaisesRegex'?
```