### PR TITLE
Do not rely on assertRaisesRegexp alias, removed in Python 3.12

### DIFF
--- a/src/ZConfig/tests/support.py
+++ b/src/ZConfig/tests/support.py
@@ -82,8 +82,11 @@ class TestHelper(object):
     # Not derived from unittest.TestCase; some test runners seem to
     # think that means this class contains tests.
 
-    assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegex',
-                                unittest.TestCase.assertRaisesRegexp)
+    try:
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegex
+    except AttributeError:
+        # Python 2; note assertRaisesRegexp is gone in Python 3.12+
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
     def load_both(self, schema_url, conf_url):
         schema = self.load_schema(schema_url)


### PR DESCRIPTION
https://docs.python.org/3.12/whatsnew/3.12.html