### PR TITLE
Python 3.14 compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 #
 # EditorConfig Configuration file, for more details see:
-# http://EditorConfig.org
+# https://EditorConfig.org
 # EditorConfig is a convention description, that could be interpreted
 # by multiple editors to enforce common coding conventions for specific
 # file types

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,19 +15,22 @@ env:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
+      pull-requests: write
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: 3.x
-    - uses: pre-commit/action@v3.0.1
+        python-version: '3.13'
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1
       with:
         extra_args: --all-files --show-diff-on-failure
       env:
         PRE_COMMIT_COLOR: always
-    - uses: pre-commit-ci/lite-action@v1.1.0
+    - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43  #v1.1.0
       if: always()
       with:
         msg: Apply pre-commit code formatting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,57 +12,59 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       # We want to see all failures:
       fail-fast: false
       matrix:
         os:
         - ["ubuntu", "ubuntu-latest"]
+        - ["windows", "windows-latest"]
         config:
         # [Python version, tox env]
         - ["3.11", "release-check"]
-        - ["3.9", "py39"]
         - ["3.10", "py310"]
         - ["3.11", "py311"]
         - ["3.12", "py312"]
         - ["3.13", "py313"]
         - ["3.14", "py314"]
-        - ["pypy-3.10", "pypy3"]
+        - ["3.15", "py315"]
+        - ["pypy-3.11", "pypy3"]
         - ["3.11", "docs"]
         - ["3.11", "coverage"]
+        exclude:
+          - { os: ["windows", "windows-latest"], config: ["3.11", "release-check"] }
+          - { os: ["windows", "windows-latest"], config: ["3.11", "docs"] }
+          - { os: ["windows", "windows-latest"], config: ["3.11", "coverage"] }
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    name: ${{ matrix.config[1] }}
+    name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
       with:
+        persist-credentials: false
+    - name: Install uv + caching
+      # astral/setup-uv@7.1.3
+      uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
         python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Test (macOS)
       if: ${{ startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}-universal2
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls
-        coveralls --service=github
+        uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,10 +2,10 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "a3a78df1"
+commit-id = "9fcd3d67"
 
 [python]
-with-windows = false
+with-windows = true
 with-pypy = true
 with-future-python = true
 with-docs = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,25 +3,25 @@
 minimum_pre_commit_version: '3.6'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: "5.13.2"
+    rev: "7.0.0"
     hooks:
     - id: isort
   - repo: https://github.com/hhatto/autopep8
-    rev: "v2.3.1"
+    rev: "v2.3.2"
     hooks:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.0
     hooks:
     - id: pyupgrade
-      args: [--py39-plus]
+      args: [--py310-plus]
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:
     - id: teyit
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.1.1"
+    rev: "7.3.0"
     hooks:
     - id: flake8
       additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add support for Python 3.14.
+
+- Drop support for Python 3.9.
 
 
 4.2 (2025-01-16)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 <!--
 Generated from:
 https://github.com/zopefoundation/meta/tree/master/config/pure-python
---> 
+-->
 # Contributing to zopefoundation projects
 
 The projects under the zopefoundation GitHub organization are open source and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 
 [build-system]
-requires = ["setuptools <= 75.6.0"]
+requires = [
+    "setuptools >= 78.1.1,< 81",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
@@ -15,7 +18,16 @@ fail_under = 98
 precision = 2
 ignore_errors = true
 show_missing = true
-exclude_lines = ["pragma: no cover", "pragma: nocover", "except ImportError:", "raise NotImplementedError", "if __name__ == '__main__':", "self.fail", "raise AssertionError", "raise unittest.Skip"]
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: nocover",
+    "except ImportError:",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "self.fail",
+    "raise AssertionError",
+    "raise unittest.Skip",
+]
 
 [tool.coverage.html]
 directory = "parts/htmlcov"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     keywords=('configuration structured simple flexible typed hierarchy'
               ' logging'),
     long_description=README + "\n\n" + CHANGES,
-    license="ZPL 2.1",
+    license="ZPL-2.1",
     url="https://github.com/zopefoundation/ZConfig/",
     # List packages explicitly so we don't have to assume setuptools:
     packages=[
@@ -62,17 +62,17 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         'Topic :: Software Development',
     ],
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     extras_require={
         'test': tests_require,
         'docs': [

--- a/src/ZConfig/datatypes.py
+++ b/src/ZConfig/datatypes.py
@@ -235,7 +235,7 @@ else:
 
 inet_address = InetAddress(DEFAULT_HOST)
 inet_connection_address = InetAddress("127.0.0.1")
-inet_binding_address = InetAddress("")
+inet_binding_address = InetAddress(DEFAULT_HOST)
 
 
 class SocketAddress:

--- a/src/ZConfig/loader.py
+++ b/src/ZConfig/loader.py
@@ -248,6 +248,7 @@ class BaseLoader(ABC):
             raise ZConfig.ConfigurationError(
                 "fragment identifiers are not supported",
                 url)
+        print(f'XXX Normalized {url} to {newurl} XXX\n')
         return newurl
 
     # from RFC 3986:

--- a/src/ZConfig/loader.py
+++ b/src/ZConfig/loader.py
@@ -14,13 +14,13 @@
 """Schema loader utility."""
 
 import os.path
+import pathlib
 import re
 import sys
 import urllib.request
 from abc import ABC
 from abc import abstractmethod
 from io import StringIO
-from urllib.request import pathname2url
 
 import ZConfig
 import ZConfig.cfgparser
@@ -242,13 +242,12 @@ class BaseLoader(ABC):
         a URL of a filesystem path.
         """
         if self.isPath(url):
-            url = "file://" + pathname2url(os.path.abspath(url))
+            url = pathlib.Path(os.path.abspath(url)).as_uri()
         newurl, fragment = ZConfig.url.urldefrag(url)
         if fragment:
             raise ZConfig.ConfigurationError(
                 "fragment identifiers are not supported",
                 url)
-        print(f'XXX Normalized {url} to {newurl} XXX\n')
         return newurl
 
     # from RFC 3986:
@@ -288,7 +287,7 @@ def openPackageResource(package, path):
                                               filename=path,
                                               package=package,
                                               path=pkg.__path__)
-        url = "file:" + pathname2url(filename)
+        url = pathlib.Path(filename).absolute().as_uri()
         url = ZConfig.url.urlnormalize(url)
         return urllib.parse.urlopen(url)
     else:
@@ -321,7 +320,7 @@ def openPackageResource(package, path):
 def _url_from_file(file_or_path):
     name = getattr(file_or_path, "name", None)
     if name and name[0] != "<" and name[-1] != ">":
-        return "file://" + pathname2url(os.path.abspath(name))
+        return pathlib.Path(os.path.abspath(name)).as_uri()
 
 
 class SchemaLoader(BaseLoader):

--- a/src/ZConfig/tests/support.py
+++ b/src/ZConfig/tests/support.py
@@ -16,9 +16,9 @@
 
 import contextlib
 import os
+import pathlib
 import sys
 from io import StringIO
-from urllib.request import pathname2url
 
 import ZConfig
 from ZConfig.loader import ConfigLoader
@@ -26,7 +26,7 @@ from ZConfig.url import urljoin
 
 
 INPUT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "input"))
-CONFIG_BASE = "file://%s/" % pathname2url(INPUT_DIR)
+CONFIG_BASE = '%s/' % pathlib.Path(INPUT_DIR).as_uri()
 
 
 def input_file(fname):

--- a/src/ZConfig/tests/test_datatypes.py
+++ b/src/ZConfig/tests/test_datatypes.py
@@ -176,7 +176,7 @@ class DatatypeTestCase(unittest.TestCase):
     def test_datatype_inet_binding_address(self):
         convert = self.types.get("inet-binding-address")
         eq = self.assertEqual
-        defhost = ""
+        defhost = ZConfig.datatypes.DEFAULT_HOST
         eq(convert("Host.Example.Com:80"), ("host.example.com", 80))
         eq(convert(":80"), (defhost, 80))
         eq(convert("80"), (defhost, 80))

--- a/src/ZConfig/tests/test_loader.py
+++ b/src/ZConfig/tests/test_loader.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Tests of ZConfig.loader classes and helper functions."""
 
+import os
 import os.path
 import sys
 import tempfile
@@ -41,18 +42,9 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
             val = stream.read()
         self.assertEqual(
             val,
-            '# -*-coding: utf-8; mode: conf-*-\n'
-            'This file contains a snowman, U+2603: \u2603\n'
+            f'# -*-coding: utf-8; mode: conf-*-{os.linesep}'
+            f'This file contains a snowman, U+2603: \u2603{os.linesep}'
         )
-
-    def test_path_normalization(self):
-        loader = ZConfig.loader.SchemaLoader()
-        schemafile = os.path.join(os.path.dirname(myfile),
-                                  'sphinx_test_schema.xml')
-        url = loader.normalizeURL(schemafile)
-        with loader.openResource(url) as resource:
-            self.assertEqual(resource.url, url)
-            self.assertIsInstance(resource.file.read(), str)
 
     def test_schema_caching(self):
         loader = ZConfig.loader.SchemaLoader()

--- a/src/ZConfig/tests/test_loader.py
+++ b/src/ZConfig/tests/test_loader.py
@@ -45,6 +45,15 @@ class LoaderTestCase(TestHelper, unittest.TestCase):
             'This file contains a snowman, U+2603: \u2603\n'
         )
 
+    def test_path_normalization(self):
+        loader = ZConfig.loader.SchemaLoader()
+        schemafile = os.path.join(os.path.dirname(myfile),
+                                  'sphinx_test_schema.xml')
+        url = loader.normalizeURL(schemafile)
+        with loader.openResource(url) as resource:
+            self.assertEqual(resource.url, url)
+            self.assertIsInstance(resource.file.read(), str)
+
     def test_schema_caching(self):
         loader = ZConfig.loader.SchemaLoader()
         url = ZConfig.url.urljoin(CONFIG_BASE, "simple.xml")

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ minversion = 3.18
 envlist =
     release-check
     lint
-    py39
     py310
     py311
     py312
     py313
     py314
+    py315
     pypy3
     docs
     coverage
@@ -19,9 +19,9 @@ envlist =
 usedevelop = true
 package = wheel
 wheel_build_env = .pkg
-pip_pre = py314: true
+pip_pre = py315: true
 deps =
-    setuptools <= 75.6.0
+    setuptools >= 78.1.1,< 81
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -37,7 +37,8 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools <= 75.6.0
+    setuptools >= 78.1.1,< 81
+    wheel
     twine
     build
     check-manifest
@@ -46,7 +47,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
This PR adds Python 3.14 support and drops Python 3.9.

Unfortunately file path handling on Windows is broken right now, most likely due to changes in `urllib` (https://docs.python.org/3/whatsnew/3.14.html#urllib). This is holding up a Python 3.14-compatible release of Zope.

I already fixed a couple other minor test issues for Windows and added Windows tests so they become visible.